### PR TITLE
feat: add dark mode

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
+import { ThemeProvider } from "@/components/theme-provider";
+import { ThemeToggle } from "@/components/theme-toggle";
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -27,13 +29,16 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        <div className="flex h-screen bg-gray-200 w-full flex-col  text-stone-900">
-          <main>{children}</main>
-        </div>
+    <html lang="en" suppressHydrationWarning>
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <ThemeProvider>
+          <div className="flex h-screen w-full flex-col">
+            <div className="flex justify-end p-4">
+              <ThemeToggle />
+            </div>
+            <main className="flex-1">{children}</main>
+          </div>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -39,7 +39,7 @@ export default function Main() {
       {/* Overlay panel for ToolsPanel on small screens */}
       {isToolsPanelOpen && (
         <div className="fixed inset-0 z-50 flex justify-end bg-black bg-opacity-30">
-          <div className="w-full bg-white h-full p-4">
+          <div className="w-full bg-background text-foreground h-full p-4">
             <button className="mb-4" onClick={() => setIsToolsPanelOpen(false)}>
               <X size={24} />
             </button>

--- a/components/assistant.tsx
+++ b/components/assistant.tsx
@@ -49,7 +49,7 @@ export default function Assistant() {
   };
 
   return (
-    <div className="h-full p-4 w-full bg-white">
+    <div className="h-full p-4 w-full bg-background">
       <Chat
         items={chatMessages}
         onSendMessage={handleSendMessage}

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -83,7 +83,7 @@ const Chat: React.FC<ChatProps> = ({
         <div className="flex-1 p-4 px-10">
           <div className="flex items-center">
             <div className="flex w-full items-center pb-4 md:pb-1">
-              <div className="flex w-full flex-col gap-1.5 rounded-[20px] p-2.5 pl-1.5 transition-colors bg-white border border-stone-200 shadow-sm">
+              <div className="flex w-full flex-col gap-1.5 rounded-[20px] p-2.5 pl-1.5 transition-colors bg-card border border-border shadow-sm">
                 <div className="flex items-end gap-1.5 md:gap-2 pl-4">
                   <div className="flex min-w-0 flex-1 flex-col">
                     <textarea
@@ -103,8 +103,8 @@ const Chat: React.FC<ChatProps> = ({
                   <button
                     disabled={!inputMessageText}
                     data-testid="send-button"
-                    className="flex size-8 items-end justify-center rounded-full bg-black text-white transition-colors hover:opacity-70 focus-visible:outline-none focus-visible:outline-black disabled:bg-[#D7D7D7] disabled:text-[#f4f4f4] disabled:hover:opacity-100"
-                  onClick={() => {
+                    className="flex size-8 items-end justify-center rounded-full bg-primary text-primary-foreground transition-colors hover:opacity-90 focus-visible:outline-none focus-visible:outline-primary disabled:bg-muted disabled:text-muted-foreground disabled:hover:opacity-100"
+                    onClick={() => {
                       onSendMessage(inputMessageText);
                       setinputMessageText("");
                     }}

--- a/components/file-search-setup.tsx
+++ b/components/file-search-setup.tsx
@@ -35,7 +35,7 @@ export default function FileSearchSetup() {
 
   return (
     <div>
-      <div className="text-sm text-zinc-500">
+      <div className="text-sm text-muted-foreground">
         Upload a file to create a new vector store, or use an existing one.
       </div>
       <div className="flex items-center gap-2 mt-2 h-10">
@@ -46,7 +46,7 @@ export default function FileSearchSetup() {
           {vectorStore?.id ? (
             <div className="flex items-center justify-between flex-1 min-w-0">
               <div className="flex items-center gap-2 min-w-0">
-                <div className="text-zinc-400  text-xs font-mono flex-1 text-ellipsis truncate">
+                <div className="text-muted-foreground text-xs font-mono flex-1 text-ellipsis truncate">
                   {vectorStore.id}
                 </div>
                 <TooltipProvider>
@@ -55,7 +55,7 @@ export default function FileSearchSetup() {
                       <CircleX
                         onClick={() => unlinkStore()}
                         size={16}
-                        className="cursor-pointer text-zinc-400 mb-0.5 shrink-0 mt-0.5 hover:text-zinc-700 transition-all"
+                        className="cursor-pointer text-muted-foreground mb-0.5 shrink-0 mt-0.5 hover:text-foreground transition-all"
                       />
                     </TooltipTrigger>
                     <TooltipContent className="mr-2">
@@ -72,7 +72,7 @@ export default function FileSearchSetup() {
                 placeholder="ID (vs_XXXX...)"
                 value={newStoreId}
                 onChange={(e) => setNewStoreId(e.target.value)}
-                className="border border-zinc-300 rounded text-sm bg-white"
+                className="border border-border rounded text-sm bg-background"
                 onKeyDown={(e) => {
                   if (e.key === "Enter") {
                     handleAddStore(newStoreId);
@@ -80,7 +80,7 @@ export default function FileSearchSetup() {
                 }}
               />
               <div
-                className="text-zinc-400 text-sm px-1 transition-colors hover:text-zinc-600 cursor-pointer"
+                className="text-sm px-1 transition-colors text-muted-foreground hover:text-foreground cursor-pointer"
                 onClick={() => handleAddStore(newStoreId)}
               >
                 Add

--- a/components/file-upload.tsx
+++ b/components/file-upload.tsx
@@ -174,7 +174,7 @@ export default function FileUpload({
   return (
     <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
       <DialogTrigger asChild>
-        <div className="bg-white rounded-full flex items-center justify-center py-1 px-3 border border-zinc-200 gap-1 font-medium text-sm cursor-pointer hover:bg-zinc-50 transition-all">
+        <div className="bg-secondary rounded-full flex items-center justify-center py-1 px-3 border border-border gap-1 font-medium text-sm cursor-pointer hover:bg-secondary/90 transition-all">
           <Plus size={16} />
           Upload
         </div>
@@ -231,14 +231,14 @@ export default function FileUpload({
           <div className="flex justify-center items-center mb-4 h-[200px]">
             {file ? (
               <div className="flex flex-col items-start">
-                <div className="text-zinc-400">Loaded file</div>
+                <div className="text-muted-foreground">Loaded file</div>
                 <div className="flex items-center mt-2">
-                  <div className="text-zinc-900 mr-2">{file.name}</div>
+                  <div className="text-foreground mr-2">{file.name}</div>
 
                   <Trash2
                     onClick={removeFile}
                     size={16}
-                    className="cursor-pointer text-zinc-900"
+                    className="cursor-pointer text-foreground"
                   />
                 </div>
               </div>
@@ -252,13 +252,13 @@ export default function FileUpload({
                   <div
                     className={`absolute rounded-full transition-all duration-300 ${
                       isDragActive
-                        ? "h-56 w-56 bg-zinc-100"
+                        ? "h-56 w-56 bg-muted"
                         : "h-0 w-0 bg-transparent"
                     }`}
                   ></div>
                   <div className="flex flex-col items-center text-center z-10 cursor-pointer">
-                    <FilePlus2 className="mb-4 size-8 text-zinc-700" />
-                    <div className="text-zinc-700">Upload a file</div>
+                    <FilePlus2 className="mb-4 size-8 text-muted-foreground" />
+                    <div className="text-muted-foreground">Upload a file</div>
                   </div>
                 </div>
               </div>

--- a/components/google-integration.tsx
+++ b/components/google-integration.tsx
@@ -65,11 +65,11 @@ export default function GoogleIntegrationPanel() {
         </div>
       ) : (
         <div className="space-y-2">
-          <div className="flex items-center gap-2 rounded-lg shadow-sm border p-3 bg-white">
+          <div className="flex items-center gap-2 rounded-lg shadow-sm border p-3 bg-card">
             <div className="bg-blue-100 text-blue-500 rounded-md p-1">
               <Check size={16} />
             </div>
-            <p className="text-sm text-zinc-800">Google OAuth set up</p>
+            <p className="text-sm text-card-foreground">Google OAuth set up</p>
           </div>
         </div>
       )}

--- a/components/loading-message.tsx
+++ b/components/loading-message.tsx
@@ -5,8 +5,8 @@ const LoadingMessage: React.FC = () => {
     <div className="text-sm">
       <div className="flex flex-col">
         <div className="flex">
-          <div className="mr-4 rounded-[16px] px-4 py-2 md:mr-24 text-black bg-white font-light">
-            <div className="w-3 h-3 animate-pulse bg-black rounded-full" />
+          <div className="mr-4 rounded-[16px] px-4 py-2 md:mr-24 text-card-foreground bg-card font-light">
+            <div className="w-3 h-3 animate-pulse bg-foreground rounded-full" />
           </div>
         </div>
       </div>

--- a/components/mcp-approval.tsx
+++ b/components/mcp-approval.tsx
@@ -19,7 +19,7 @@ export default function McpApproval({ item, onRespond }: Props) {
   return (
     <div className="flex flex-col">
       <div className="flex">
-        <div className="mr-4 rounded-[16px] p-4 md:mr-24 text-black bg-gray-100 font-light">
+        <div className="mr-4 rounded-[16px] p-4 md:mr-24 text-card-foreground bg-card font-light">
           <div className="mb-2 text-sm">
             Request to execute tool{" "}
             <span className="font-medium">{item.name}</span> on server{" "}
@@ -33,7 +33,7 @@ export default function McpApproval({ item, onRespond }: Props) {
               size="sm"
               disabled={disabled}
               onClick={() => handle(false)}
-              className="bg-gray-200 text-gray-700 hover:bg-gray-300 hover:text-gray-800"
+              className="bg-secondary text-secondary-foreground hover:bg-secondary/90"
             >
               Decline
             </Button>

--- a/components/mcp-config.tsx
+++ b/components/mcp-config.tsx
@@ -19,15 +19,15 @@ export default function McpConfig() {
   return (
     <div>
       <div className="flex items-center justify-between">
-        <div className="text-zinc-600 text-sm">Server details</div>
+        <div className="text-sm text-muted-foreground">Server details</div>
         <div
-          className="text-zinc-400 text-sm px-1 transition-colors hover:text-zinc-600 cursor-pointer"
+          className="text-sm px-1 transition-colors text-muted-foreground hover:text-foreground cursor-pointer"
           onClick={handleClear}
         >
           Clear
         </div>
       </div>
-      <div className="mt-3 space-y-3 text-zinc-400">
+      <div className="mt-3 space-y-3 text-muted-foreground">
         <div className="flex items-center gap-2">
           <label htmlFor="server_label" className="text-sm w-24">
             Label
@@ -36,7 +36,7 @@ export default function McpConfig() {
             id="server_label"
             type="text"
             placeholder="deepwiki"
-            className="bg-white border text-sm flex-1 text-zinc-900 placeholder:text-zinc-400"
+            className="bg-background border text-sm flex-1 text-foreground placeholder:text-muted-foreground"
             value={mcpConfig.server_label}
             onChange={(e) =>
               setMcpConfig({ ...mcpConfig, server_label: e.target.value })
@@ -51,7 +51,7 @@ export default function McpConfig() {
             id="server_url"
             type="text"
             placeholder="https://example.com/mcp"
-            className="bg-white border text-sm flex-1 text-zinc-900 placeholder:text-zinc-400"
+            className="bg-background border text-sm flex-1 text-foreground placeholder:text-muted-foreground"
             value={mcpConfig.server_url}
             onChange={(e) =>
               setMcpConfig({ ...mcpConfig, server_url: e.target.value })
@@ -66,7 +66,7 @@ export default function McpConfig() {
             id="allowed_tools"
             type="text"
             placeholder="tool1,tool2"
-            className="bg-white border text-sm flex-1 text-zinc-900 placeholder:text-zinc-400"
+            className="bg-background border text-sm flex-1 text-foreground placeholder:text-muted-foreground"
             value={mcpConfig.allowed_tools}
             onChange={(e) =>
               setMcpConfig({ ...mcpConfig, allowed_tools: e.target.value })

--- a/components/mcp-tools-list.tsx
+++ b/components/mcp-tools-list.tsx
@@ -39,7 +39,7 @@ export default function McpToolsList({ item }: Props) {
   return (
     <div className="flex flex-col">
       <div className="flex">
-        <div className="mr-4 rounded-[16px] px-4 py-2 md:mr-24 text-black bg-white font-light">
+        <div className="mr-4 rounded-[16px] px-4 py-2 md:mr-24 text-card-foreground bg-card font-light">
           <div className="text-sm mb-2 text-blue-500">
             Server <span className="font-semibold">{item.server_label}</span>{" "}
             tools list

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -12,7 +12,7 @@ const Message: React.FC<MessageProps> = ({ message }) => {
       {message.role === "user" ? (
         <div className="flex justify-end">
           <div>
-            <div className="ml-4 rounded-[16px] px-4 py-2 md:ml-24 bg-[#ededed] text-stone-900  font-light">
+            <div className="ml-4 rounded-[16px] px-4 py-2 md:ml-24 bg-secondary text-secondary-foreground  font-light">
               <div>
                 <div>
                   <ReactMarkdown>
@@ -26,7 +26,7 @@ const Message: React.FC<MessageProps> = ({ message }) => {
       ) : (
         <div className="flex flex-col">
           <div className="flex">
-            <div className="mr-4 rounded-[16px] px-4 py-2 md:mr-24 text-black bg-white font-light">
+            <div className="mr-4 rounded-[16px] px-4 py-2 md:mr-24 text-card-foreground bg-card font-light">
               <div>
                 <ReactMarkdown>
                   {message.content[0].text as string}

--- a/components/panel-config.tsx
+++ b/components/panel-config.tsx
@@ -30,7 +30,7 @@ export default function PanelConfig({
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger asChild>
-              <h1 className="text-black font-medium">{title}</h1>
+              <h1 className="text-foreground font-medium">{title}</h1>
             </TooltipTrigger>
             <TooltipContent>
               <p>{tooltip}</p>

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,0 +1,51 @@
+"use client";
+import { createContext, useContext, useEffect, useState } from "react";
+
+export type Theme = "light" | "dark";
+
+interface ThemeContextValue {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>("light");
+
+  // Initialize theme from local storage or system preference
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const stored = localStorage.getItem("theme") as Theme | null;
+    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    setThemeState(stored ?? (prefersDark ? "dark" : "light"));
+  }, []);
+
+  // Update document class and local storage when theme changes
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const root = document.documentElement;
+    if (theme === "dark") {
+      root.classList.add("dark");
+    } else {
+      root.classList.remove("dark");
+    }
+    localStorage.setItem("theme", theme);
+  }, [theme]);
+
+  const setTheme = (t: Theme) => setThemeState(t);
+  const toggleTheme = () => setThemeState(theme === "dark" ? "light" : "dark");
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error("useTheme must be used within ThemeProvider");
+  return ctx;
+}

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,0 +1,25 @@
+"use client";
+import { useEffect, useState } from "react";
+import { Moon, Sun } from "lucide-react";
+import { Switch } from "@/components/ui/switch";
+import { useTheme } from "@/components/theme-provider";
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+  if (!mounted) return null;
+
+  return (
+    <div className="flex items-center space-x-2">
+      <Sun className="h-4 w-4" />
+      <Switch
+        checked={theme === "dark"}
+        onCheckedChange={(checked) => setTheme(checked ? "dark" : "light")}
+        aria-label="Toggle theme"
+      />
+      <Moon className="h-4 w-4" />
+    </div>
+  );
+}

--- a/components/tools-panel.tsx
+++ b/components/tools-panel.tsx
@@ -32,7 +32,7 @@ export default function ContextPanel() {
       .catch(() => setOauthConfigured(false));
   }, []);
   return (
-    <div className="h-full p-8 w-full bg-[#f9f9f9] rounded-t-xl md:rounded-none border-l-1 border-stone-100">
+    <div className="h-full p-8 w-full bg-secondary rounded-t-xl md:rounded-none border-l border-border">
       <div className="flex flex-col overflow-y-scroll h-full">
         <PanelConfig
           title="File Search"

--- a/components/websearch-config.tsx
+++ b/components/websearch-config.tsx
@@ -36,15 +36,15 @@ export default function WebSearchSettings() {
   return (
     <div>
       <div className="flex items-center justify-between">
-        <div className="text-zinc-600 text-sm">User&apos;s location</div>
+        <div className="text-sm text-muted-foreground">User&apos;s location</div>
         <div
-          className="text-zinc-400 text-sm px-1 transition-colors hover:text-zinc-600 cursor-pointer"
+          className="text-sm px-1 transition-colors text-muted-foreground hover:text-foreground cursor-pointer"
           onClick={handleClear}
         >
           Clear
         </div>
       </div>
-      <div className="mt-3 space-y-3 text-zinc-400">
+      <div className="mt-3 space-y-3 text-muted-foreground">
         <div className="flex items-center gap-2">
           <label htmlFor="country" className="text-sm w-20">
             Country
@@ -63,7 +63,7 @@ export default function WebSearchSettings() {
             id="region"
             type="text"
             placeholder="Region"
-            className="bg-white border text-sm flex-1 text-zinc-900 placeholder:text-zinc-400"
+            className="bg-background border text-sm flex-1 text-foreground placeholder:text-muted-foreground"
             value={webSearchConfig.user_location?.region ?? ""}
             onChange={(e) => handleLocationChange("region", e.target.value)}
           />
@@ -77,7 +77,7 @@ export default function WebSearchSettings() {
             id="city"
             type="text"
             placeholder="City"
-            className="bg-white border text-sm flex-1 text-zinc-900 placeholder:text-zinc-400"
+            className="bg-background border text-sm flex-1 text-foreground placeholder:text-muted-foreground"
             value={webSearchConfig.user_location?.city ?? ""}
             onChange={(e) => handleLocationChange("city", e.target.value)}
           />


### PR DESCRIPTION
## Summary
- add a simple theme provider and toggle to switch between light and dark modes
- wrap application with theme provider and update UI elements to respect background/text variables
- standardize styling across components to use theme-aware colors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b852d64e54832696978b31341e25c4