### PR TITLE
feat: add dark mode toggle

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
+import ThemeToggle from "@/components/theme-toggle";
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -27,11 +28,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        <div className="flex h-screen bg-gray-200 w-full flex-col  text-stone-900">
+    <html lang="en" suppressHydrationWarning>
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <div className="flex h-screen w-full flex-col">
+          <div className="absolute top-4 right-4">
+            <ThemeToggle />
+          </div>
           <main>{children}</main>
         </div>
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -39,7 +39,7 @@ export default function Main() {
       {/* Overlay panel for ToolsPanel on small screens */}
       {isToolsPanelOpen && (
         <div className="fixed inset-0 z-50 flex justify-end bg-black bg-opacity-30">
-          <div className="w-full bg-white h-full p-4">
+          <div className="w-full h-full p-4 bg-background text-foreground">
             <button className="mb-4" onClick={() => setIsToolsPanelOpen(false)}>
               <X size={24} />
             </button>

--- a/components/assistant.tsx
+++ b/components/assistant.tsx
@@ -49,7 +49,7 @@ export default function Assistant() {
   };
 
   return (
-    <div className="h-full p-4 w-full bg-white">
+    <div className="h-full p-4 w-full bg-background">
       <Chat
         items={chatMessages}
         onSendMessage={handleSendMessage}

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -83,7 +83,7 @@ const Chat: React.FC<ChatProps> = ({
         <div className="flex-1 p-4 px-10">
           <div className="flex items-center">
             <div className="flex w-full items-center pb-4 md:pb-1">
-              <div className="flex w-full flex-col gap-1.5 rounded-[20px] p-2.5 pl-1.5 transition-colors bg-white border border-stone-200 shadow-sm">
+              <div className="flex w-full flex-col gap-1.5 rounded-[20px] p-2.5 pl-1.5 transition-colors bg-card border shadow-sm">
                 <div className="flex items-end gap-1.5 md:gap-2 pl-4">
                   <div className="flex min-w-0 flex-1 flex-col">
                     <textarea
@@ -103,8 +103,8 @@ const Chat: React.FC<ChatProps> = ({
                   <button
                     disabled={!inputMessageText}
                     data-testid="send-button"
-                    className="flex size-8 items-end justify-center rounded-full bg-black text-white transition-colors hover:opacity-70 focus-visible:outline-none focus-visible:outline-black disabled:bg-[#D7D7D7] disabled:text-[#f4f4f4] disabled:hover:opacity-100"
-                  onClick={() => {
+                    className="flex size-8 items-end justify-center rounded-full bg-primary text-primary-foreground transition-colors hover:opacity-70 focus-visible:outline-none focus-visible:outline-primary disabled:bg-muted disabled:text-muted-foreground disabled:hover:opacity-100"
+                    onClick={() => {
                       onSendMessage(inputMessageText);
                       setinputMessageText("");
                     }}

--- a/components/file-search-setup.tsx
+++ b/components/file-search-setup.tsx
@@ -72,7 +72,7 @@ export default function FileSearchSetup() {
                 placeholder="ID (vs_XXXX...)"
                 value={newStoreId}
                 onChange={(e) => setNewStoreId(e.target.value)}
-                className="border border-zinc-300 rounded text-sm bg-white"
+                className="border rounded text-sm bg-background text-foreground placeholder:text-muted-foreground"
                 onKeyDown={(e) => {
                   if (e.key === "Enter") {
                     handleAddStore(newStoreId);
@@ -80,7 +80,7 @@ export default function FileSearchSetup() {
                 }}
               />
               <div
-                className="text-zinc-400 text-sm px-1 transition-colors hover:text-zinc-600 cursor-pointer"
+                className="text-sm px-1 transition-colors cursor-pointer text-muted-foreground hover:text-foreground"
                 onClick={() => handleAddStore(newStoreId)}
               >
                 Add

--- a/components/file-upload.tsx
+++ b/components/file-upload.tsx
@@ -174,7 +174,7 @@ export default function FileUpload({
   return (
     <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
       <DialogTrigger asChild>
-        <div className="bg-white rounded-full flex items-center justify-center py-1 px-3 border border-zinc-200 gap-1 font-medium text-sm cursor-pointer hover:bg-zinc-50 transition-all">
+        <div className="bg-card text-foreground rounded-full flex items-center justify-center py-1 px-3 border gap-1 font-medium text-sm cursor-pointer hover:bg-accent transition-all">
           <Plus size={16} />
           Upload
         </div>

--- a/components/google-integration.tsx
+++ b/components/google-integration.tsx
@@ -65,11 +65,11 @@ export default function GoogleIntegrationPanel() {
         </div>
       ) : (
         <div className="space-y-2">
-          <div className="flex items-center gap-2 rounded-lg shadow-sm border p-3 bg-white">
+          <div className="flex items-center gap-2 rounded-lg shadow-sm border p-3 bg-card">
             <div className="bg-blue-100 text-blue-500 rounded-md p-1">
               <Check size={16} />
             </div>
-            <p className="text-sm text-zinc-800">Google OAuth set up</p>
+            <p className="text-sm text-foreground">Google OAuth set up</p>
           </div>
         </div>
       )}

--- a/components/loading-message.tsx
+++ b/components/loading-message.tsx
@@ -5,8 +5,8 @@ const LoadingMessage: React.FC = () => {
     <div className="text-sm">
       <div className="flex flex-col">
         <div className="flex">
-          <div className="mr-4 rounded-[16px] px-4 py-2 md:mr-24 text-black bg-white font-light">
-            <div className="w-3 h-3 animate-pulse bg-black rounded-full" />
+          <div className="mr-4 rounded-[16px] px-4 py-2 md:mr-24 text-card-foreground bg-card font-light">
+            <div className="w-3 h-3 animate-pulse bg-foreground rounded-full" />
           </div>
         </div>
       </div>

--- a/components/mcp-approval.tsx
+++ b/components/mcp-approval.tsx
@@ -19,7 +19,7 @@ export default function McpApproval({ item, onRespond }: Props) {
   return (
     <div className="flex flex-col">
       <div className="flex">
-        <div className="mr-4 rounded-[16px] p-4 md:mr-24 text-black bg-gray-100 font-light">
+        <div className="mr-4 rounded-[16px] p-4 md:mr-24 text-card-foreground bg-card font-light">
           <div className="mb-2 text-sm">
             Request to execute tool{" "}
             <span className="font-medium">{item.name}</span> on server{" "}
@@ -33,7 +33,7 @@ export default function McpApproval({ item, onRespond }: Props) {
               size="sm"
               disabled={disabled}
               onClick={() => handle(false)}
-              className="bg-gray-200 text-gray-700 hover:bg-gray-300 hover:text-gray-800"
+              className="bg-muted text-muted-foreground hover:bg-muted/80"
             >
               Decline
             </Button>

--- a/components/mcp-config.tsx
+++ b/components/mcp-config.tsx
@@ -19,15 +19,15 @@ export default function McpConfig() {
   return (
     <div>
       <div className="flex items-center justify-between">
-        <div className="text-zinc-600 text-sm">Server details</div>
+        <div className="text-sm text-foreground">Server details</div>
         <div
-          className="text-zinc-400 text-sm px-1 transition-colors hover:text-zinc-600 cursor-pointer"
+          className="text-sm px-1 transition-colors cursor-pointer text-muted-foreground hover:text-foreground"
           onClick={handleClear}
         >
           Clear
         </div>
       </div>
-      <div className="mt-3 space-y-3 text-zinc-400">
+      <div className="mt-3 space-y-3 text-muted-foreground">
         <div className="flex items-center gap-2">
           <label htmlFor="server_label" className="text-sm w-24">
             Label
@@ -36,7 +36,7 @@ export default function McpConfig() {
             id="server_label"
             type="text"
             placeholder="deepwiki"
-            className="bg-white border text-sm flex-1 text-zinc-900 placeholder:text-zinc-400"
+            className="bg-background border text-sm flex-1 text-foreground placeholder:text-muted-foreground"
             value={mcpConfig.server_label}
             onChange={(e) =>
               setMcpConfig({ ...mcpConfig, server_label: e.target.value })
@@ -51,7 +51,7 @@ export default function McpConfig() {
             id="server_url"
             type="text"
             placeholder="https://example.com/mcp"
-            className="bg-white border text-sm flex-1 text-zinc-900 placeholder:text-zinc-400"
+            className="bg-background border text-sm flex-1 text-foreground placeholder:text-muted-foreground"
             value={mcpConfig.server_url}
             onChange={(e) =>
               setMcpConfig({ ...mcpConfig, server_url: e.target.value })
@@ -66,7 +66,7 @@ export default function McpConfig() {
             id="allowed_tools"
             type="text"
             placeholder="tool1,tool2"
-            className="bg-white border text-sm flex-1 text-zinc-900 placeholder:text-zinc-400"
+            className="bg-background border text-sm flex-1 text-foreground placeholder:text-muted-foreground"
             value={mcpConfig.allowed_tools}
             onChange={(e) =>
               setMcpConfig({ ...mcpConfig, allowed_tools: e.target.value })

--- a/components/mcp-tools-list.tsx
+++ b/components/mcp-tools-list.tsx
@@ -39,7 +39,7 @@ export default function McpToolsList({ item }: Props) {
   return (
     <div className="flex flex-col">
       <div className="flex">
-        <div className="mr-4 rounded-[16px] px-4 py-2 md:mr-24 text-black bg-white font-light">
+        <div className="mr-4 rounded-[16px] px-4 py-2 md:mr-24 text-card-foreground bg-card font-light">
           <div className="text-sm mb-2 text-blue-500">
             Server <span className="font-semibold">{item.server_label}</span>{" "}
             tools list

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -12,7 +12,7 @@ const Message: React.FC<MessageProps> = ({ message }) => {
       {message.role === "user" ? (
         <div className="flex justify-end">
           <div>
-            <div className="ml-4 rounded-[16px] px-4 py-2 md:ml-24 bg-[#ededed] text-stone-900  font-light">
+            <div className="ml-4 rounded-[16px] px-4 py-2 md:ml-24 bg-secondary text-secondary-foreground font-light">
               <div>
                 <div>
                   <ReactMarkdown>
@@ -26,7 +26,7 @@ const Message: React.FC<MessageProps> = ({ message }) => {
       ) : (
         <div className="flex flex-col">
           <div className="flex">
-            <div className="mr-4 rounded-[16px] px-4 py-2 md:mr-24 text-black bg-white font-light">
+            <div className="mr-4 rounded-[16px] px-4 py-2 md:mr-24 text-card-foreground bg-card font-light">
               <div>
                 <ReactMarkdown>
                   {message.content[0].text as string}

--- a/components/panel-config.tsx
+++ b/components/panel-config.tsx
@@ -30,7 +30,7 @@ export default function PanelConfig({
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger asChild>
-              <h1 className="text-black font-medium">{title}</h1>
+              <h1 className="text-foreground font-medium">{title}</h1>
             </TooltipTrigger>
             <TooltipContent>
               <p>{tooltip}</p>

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,0 +1,36 @@
+"use client";
+import { useEffect, useState } from "react";
+import { Moon, Sun } from "lucide-react";
+import { Switch } from "./ui/switch";
+
+export default function ThemeToggle() {
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const stored = localStorage.getItem("theme");
+    if (stored === "dark") {
+      document.documentElement.classList.add("dark");
+      setIsDark(true);
+    }
+  }, []);
+
+  const toggle = (checked: boolean) => {
+    setIsDark(checked);
+    if (checked) {
+      document.documentElement.classList.add("dark");
+      localStorage.setItem("theme", "dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+      localStorage.setItem("theme", "light");
+    }
+  };
+
+  return (
+    <div className="flex items-center space-x-2">
+      <Sun className="h-4 w-4" />
+      <Switch checked={isDark} onCheckedChange={toggle} />
+      <Moon className="h-4 w-4" />
+    </div>
+  );
+}

--- a/components/websearch-config.tsx
+++ b/components/websearch-config.tsx
@@ -36,15 +36,15 @@ export default function WebSearchSettings() {
   return (
     <div>
       <div className="flex items-center justify-between">
-        <div className="text-zinc-600 text-sm">User&apos;s location</div>
+        <div className="text-sm text-foreground">User&apos;s location</div>
         <div
-          className="text-zinc-400 text-sm px-1 transition-colors hover:text-zinc-600 cursor-pointer"
+          className="text-sm px-1 transition-colors cursor-pointer text-muted-foreground hover:text-foreground"
           onClick={handleClear}
         >
           Clear
         </div>
       </div>
-      <div className="mt-3 space-y-3 text-zinc-400">
+      <div className="mt-3 space-y-3 text-muted-foreground">
         <div className="flex items-center gap-2">
           <label htmlFor="country" className="text-sm w-20">
             Country
@@ -63,7 +63,7 @@ export default function WebSearchSettings() {
             id="region"
             type="text"
             placeholder="Region"
-            className="bg-white border text-sm flex-1 text-zinc-900 placeholder:text-zinc-400"
+            className="bg-background border text-sm flex-1 text-foreground placeholder:text-muted-foreground"
             value={webSearchConfig.user_location?.region ?? ""}
             onChange={(e) => handleLocationChange("region", e.target.value)}
           />
@@ -77,7 +77,7 @@ export default function WebSearchSettings() {
             id="city"
             type="text"
             placeholder="City"
-            className="bg-white border text-sm flex-1 text-zinc-900 placeholder:text-zinc-400"
+            className="bg-background border text-sm flex-1 text-foreground placeholder:text-muted-foreground"
             value={webSearchConfig.user_location?.city ?? ""}
             onChange={(e) => handleLocationChange("city", e.target.value)}
           />


### PR DESCRIPTION
## Summary
- add theme toggle component with local storage
- apply theme tokens across chat UI
- expose toggle in layout for user switching

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b85db379a883268f19ba842b7dbc6c