### PR TITLE
Add dark mode support with toggle

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
+import { ThemeProvider } from "@/components/theme-provider";
+import ThemeToggle from "@/components/theme-toggle";
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -27,13 +29,18 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <div className="flex h-screen bg-gray-200 w-full flex-col  text-stone-900">
-          <main>{children}</main>
-        </div>
+        <ThemeProvider>
+          <div className="flex min-h-screen w-full flex-col">
+            <div className="absolute right-4 top-4">
+              <ThemeToggle />
+            </div>
+            <main className="flex-1">{children}</main>
+          </div>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -39,7 +39,7 @@ export default function Main() {
       {/* Overlay panel for ToolsPanel on small screens */}
       {isToolsPanelOpen && (
         <div className="fixed inset-0 z-50 flex justify-end bg-black bg-opacity-30">
-          <div className="w-full bg-white h-full p-4">
+          <div className="w-full h-full p-4 bg-background">
             <button className="mb-4" onClick={() => setIsToolsPanelOpen(false)}>
               <X size={24} />
             </button>

--- a/components/annotations.tsx
+++ b/components/annotations.tsx
@@ -15,7 +15,7 @@ export type Annotation = {
 
 const AnnotationPill = ({ annotation }: { annotation: Annotation }) => {
   const className =
-    "inline-block text-nowrap px-3 py-1 rounded-full text-xs max-w-48 shrink-0 text-ellipsis overflow-hidden bg-[#ededed] text-zinc-500";
+    "inline-block text-nowrap px-3 py-1 rounded-full text-xs max-w-48 shrink-0 text-ellipsis overflow-hidden bg-muted text-muted-foreground";
 
   switch (annotation.type) {
     case "file_citation":

--- a/components/assistant.tsx
+++ b/components/assistant.tsx
@@ -49,7 +49,7 @@ export default function Assistant() {
   };
 
   return (
-    <div className="h-full p-4 w-full bg-white">
+    <div className="h-full p-4 w-full bg-background">
       <Chat
         items={chatMessages}
         onSendMessage={handleSendMessage}

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -83,7 +83,7 @@ const Chat: React.FC<ChatProps> = ({
         <div className="flex-1 p-4 px-10">
           <div className="flex items-center">
             <div className="flex w-full items-center pb-4 md:pb-1">
-              <div className="flex w-full flex-col gap-1.5 rounded-[20px] p-2.5 pl-1.5 transition-colors bg-white border border-stone-200 shadow-sm">
+              <div className="flex w-full flex-col gap-1.5 rounded-[20px] p-2.5 pl-1.5 transition-colors border bg-background shadow-sm">
                 <div className="flex items-end gap-1.5 md:gap-2 pl-4">
                   <div className="flex min-w-0 flex-1 flex-col">
                     <textarea
@@ -103,8 +103,8 @@ const Chat: React.FC<ChatProps> = ({
                   <button
                     disabled={!inputMessageText}
                     data-testid="send-button"
-                    className="flex size-8 items-end justify-center rounded-full bg-black text-white transition-colors hover:opacity-70 focus-visible:outline-none focus-visible:outline-black disabled:bg-[#D7D7D7] disabled:text-[#f4f4f4] disabled:hover:opacity-100"
-                  onClick={() => {
+                    className="flex size-8 items-end justify-center rounded-full bg-primary text-primary-foreground transition-colors hover:opacity-70 focus-visible:outline-none focus-visible:outline-primary disabled:bg-muted disabled:text-muted-foreground disabled:hover:opacity-100"
+                    onClick={() => {
                       onSendMessage(inputMessageText);
                       setinputMessageText("");
                     }}

--- a/components/file-search-setup.tsx
+++ b/components/file-search-setup.tsx
@@ -35,7 +35,7 @@ export default function FileSearchSetup() {
 
   return (
     <div>
-      <div className="text-sm text-zinc-500">
+      <div className="text-sm text-muted-foreground">
         Upload a file to create a new vector store, or use an existing one.
       </div>
       <div className="flex items-center gap-2 mt-2 h-10">
@@ -46,7 +46,7 @@ export default function FileSearchSetup() {
           {vectorStore?.id ? (
             <div className="flex items-center justify-between flex-1 min-w-0">
               <div className="flex items-center gap-2 min-w-0">
-                <div className="text-zinc-400  text-xs font-mono flex-1 text-ellipsis truncate">
+                <div className="text-xs font-mono flex-1 text-ellipsis truncate text-muted-foreground">
                   {vectorStore.id}
                 </div>
                 <TooltipProvider>
@@ -55,7 +55,7 @@ export default function FileSearchSetup() {
                       <CircleX
                         onClick={() => unlinkStore()}
                         size={16}
-                        className="cursor-pointer text-zinc-400 mb-0.5 shrink-0 mt-0.5 hover:text-zinc-700 transition-all"
+                        className="cursor-pointer text-muted-foreground mb-0.5 shrink-0 mt-0.5 hover:text-foreground transition-all"
                       />
                     </TooltipTrigger>
                     <TooltipContent className="mr-2">
@@ -72,7 +72,7 @@ export default function FileSearchSetup() {
                 placeholder="ID (vs_XXXX...)"
                 value={newStoreId}
                 onChange={(e) => setNewStoreId(e.target.value)}
-                className="border border-zinc-300 rounded text-sm bg-white"
+                className="border border-input rounded text-sm bg-background text-foreground placeholder:text-muted-foreground"
                 onKeyDown={(e) => {
                   if (e.key === "Enter") {
                     handleAddStore(newStoreId);
@@ -80,7 +80,7 @@ export default function FileSearchSetup() {
                 }}
               />
               <div
-                className="text-zinc-400 text-sm px-1 transition-colors hover:text-zinc-600 cursor-pointer"
+                className="text-muted-foreground text-sm px-1 transition-colors hover:text-foreground cursor-pointer"
                 onClick={() => handleAddStore(newStoreId)}
               >
                 Add

--- a/components/file-upload.tsx
+++ b/components/file-upload.tsx
@@ -174,7 +174,7 @@ export default function FileUpload({
   return (
     <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
       <DialogTrigger asChild>
-        <div className="bg-white rounded-full flex items-center justify-center py-1 px-3 border border-zinc-200 gap-1 font-medium text-sm cursor-pointer hover:bg-zinc-50 transition-all">
+        <div className="bg-background rounded-full flex items-center justify-center py-1 px-3 border border-input gap-1 font-medium text-sm cursor-pointer hover:bg-accent transition-all">
           <Plus size={16} />
           Upload
         </div>
@@ -189,7 +189,7 @@ export default function FileUpload({
               <div className="flex items-start gap-2 text-sm">
                 <label className="font-medium w-72" htmlFor="storeName">
                   New vector store name
-                  <div className="text-xs text-zinc-400">
+                  <div className="text-xs text-muted-foreground">
                     A new store will be created when you upload a file.
                   </div>
                 </label>
@@ -207,7 +207,7 @@ export default function FileUpload({
                   <div className="text-sm font-medium w-24 text-nowrap">
                     Vector store
                   </div>
-                  <div className="text-zinc-400  text-xs font-mono flex-1 text-ellipsis truncate">
+                  <div className="text-xs font-mono flex-1 text-ellipsis truncate text-muted-foreground">
                     {vectorStoreId}
                   </div>
                   <TooltipProvider>
@@ -216,7 +216,7 @@ export default function FileUpload({
                         <CircleX
                           onClick={() => onUnlinkStore()}
                           size={16}
-                          className="cursor-pointer text-zinc-400 mb-0.5 shrink-0 mt-0.5 hover:text-zinc-700 transition-all"
+                          className="cursor-pointer text-muted-foreground mb-0.5 shrink-0 mt-0.5 hover:text-foreground transition-all"
                         />
                       </TooltipTrigger>
                       <TooltipContent>
@@ -231,14 +231,14 @@ export default function FileUpload({
           <div className="flex justify-center items-center mb-4 h-[200px]">
             {file ? (
               <div className="flex flex-col items-start">
-                <div className="text-zinc-400">Loaded file</div>
+                <div className="text-muted-foreground">Loaded file</div>
                 <div className="flex items-center mt-2">
-                  <div className="text-zinc-900 mr-2">{file.name}</div>
+                  <div className="mr-2 text-foreground">{file.name}</div>
 
                   <Trash2
                     onClick={removeFile}
                     size={16}
-                    className="cursor-pointer text-zinc-900"
+                    className="cursor-pointer text-foreground"
                   />
                 </div>
               </div>
@@ -252,13 +252,13 @@ export default function FileUpload({
                   <div
                     className={`absolute rounded-full transition-all duration-300 ${
                       isDragActive
-                        ? "h-56 w-56 bg-zinc-100"
+                        ? "h-56 w-56 bg-muted"
                         : "h-0 w-0 bg-transparent"
                     }`}
                   ></div>
                   <div className="flex flex-col items-center text-center z-10 cursor-pointer">
-                    <FilePlus2 className="mb-4 size-8 text-zinc-700" />
-                    <div className="text-zinc-700">Upload a file</div>
+                    <FilePlus2 className="mb-4 size-8 text-muted-foreground" />
+                    <div className="text-foreground">Upload a file</div>
                   </div>
                 </div>
               </div>

--- a/components/functions-view.tsx
+++ b/components/functions-view.tsx
@@ -19,7 +19,7 @@ const getToolArgs = (parameters: {
       {Object.entries(parameters).map(([key, value]) => (
         <div key={key} className="flex items-center text-xs space-x-2 my-1">
           <span className="text-blue-500">{key}:</span>
-          <span className="text-zinc-400">{value?.type}</span>
+          <span className="text-muted-foreground">{value?.type}</span>
         </div>
       ))}
     </div>
@@ -34,7 +34,7 @@ export default function FunctionsView() {
           <div className="bg-blue-100 text-blue-500 rounded-md p-1">
             <Code size={16} />
           </div>
-          <div className="text-zinc-800 font-mono text-sm mt-0.5">
+          <div className="font-mono text-sm mt-0.5 text-foreground">
             {tool.name}(
             {tool.parameters && Object.keys(tool.parameters).length > 0
               ? getToolArgs(tool.parameters)

--- a/components/google-integration.tsx
+++ b/components/google-integration.tsx
@@ -65,11 +65,11 @@ export default function GoogleIntegrationPanel() {
         </div>
       ) : (
         <div className="space-y-2">
-          <div className="flex items-center gap-2 rounded-lg shadow-sm border p-3 bg-white">
+          <div className="flex items-center gap-2 rounded-lg shadow-sm border p-3 bg-background">
             <div className="bg-blue-100 text-blue-500 rounded-md p-1">
               <Check size={16} />
             </div>
-            <p className="text-sm text-zinc-800">Google OAuth set up</p>
+            <p className="text-sm text-foreground">Google OAuth set up</p>
           </div>
         </div>
       )}

--- a/components/loading-message.tsx
+++ b/components/loading-message.tsx
@@ -5,8 +5,8 @@ const LoadingMessage: React.FC = () => {
     <div className="text-sm">
       <div className="flex flex-col">
         <div className="flex">
-          <div className="mr-4 rounded-[16px] px-4 py-2 md:mr-24 text-black bg-white font-light">
-            <div className="w-3 h-3 animate-pulse bg-black rounded-full" />
+          <div className="mr-4 rounded-[16px] px-4 py-2 md:mr-24 bg-card text-foreground font-light">
+            <div className="w-3 h-3 rounded-full bg-primary animate-pulse" />
           </div>
         </div>
       </div>

--- a/components/mcp-approval.tsx
+++ b/components/mcp-approval.tsx
@@ -19,7 +19,7 @@ export default function McpApproval({ item, onRespond }: Props) {
   return (
     <div className="flex flex-col">
       <div className="flex">
-        <div className="mr-4 rounded-[16px] p-4 md:mr-24 text-black bg-gray-100 font-light">
+        <div className="mr-4 rounded-[16px] p-4 md:mr-24 bg-muted text-foreground font-light">
           <div className="mb-2 text-sm">
             Request to execute tool{" "}
             <span className="font-medium">{item.name}</span> on server{" "}
@@ -31,9 +31,9 @@ export default function McpApproval({ item, onRespond }: Props) {
             </Button>
             <Button
               size="sm"
+              variant="secondary"
               disabled={disabled}
               onClick={() => handle(false)}
-              className="bg-gray-200 text-gray-700 hover:bg-gray-300 hover:text-gray-800"
             >
               Decline
             </Button>

--- a/components/mcp-config.tsx
+++ b/components/mcp-config.tsx
@@ -19,15 +19,15 @@ export default function McpConfig() {
   return (
     <div>
       <div className="flex items-center justify-between">
-        <div className="text-zinc-600 text-sm">Server details</div>
+        <div className="text-sm text-muted-foreground">Server details</div>
         <div
-          className="text-zinc-400 text-sm px-1 transition-colors hover:text-zinc-600 cursor-pointer"
+          className="px-1 text-sm text-muted-foreground transition-colors hover:text-foreground cursor-pointer"
           onClick={handleClear}
         >
           Clear
         </div>
       </div>
-      <div className="mt-3 space-y-3 text-zinc-400">
+      <div className="mt-3 space-y-3 text-muted-foreground">
         <div className="flex items-center gap-2">
           <label htmlFor="server_label" className="text-sm w-24">
             Label
@@ -36,7 +36,7 @@ export default function McpConfig() {
             id="server_label"
             type="text"
             placeholder="deepwiki"
-            className="bg-white border text-sm flex-1 text-zinc-900 placeholder:text-zinc-400"
+            className="bg-background border text-sm flex-1 text-foreground placeholder:text-muted-foreground"
             value={mcpConfig.server_label}
             onChange={(e) =>
               setMcpConfig({ ...mcpConfig, server_label: e.target.value })
@@ -51,7 +51,7 @@ export default function McpConfig() {
             id="server_url"
             type="text"
             placeholder="https://example.com/mcp"
-            className="bg-white border text-sm flex-1 text-zinc-900 placeholder:text-zinc-400"
+            className="bg-background border text-sm flex-1 text-foreground placeholder:text-muted-foreground"
             value={mcpConfig.server_url}
             onChange={(e) =>
               setMcpConfig({ ...mcpConfig, server_url: e.target.value })
@@ -66,7 +66,7 @@ export default function McpConfig() {
             id="allowed_tools"
             type="text"
             placeholder="tool1,tool2"
-            className="bg-white border text-sm flex-1 text-zinc-900 placeholder:text-zinc-400"
+            className="bg-background border text-sm flex-1 text-foreground placeholder:text-muted-foreground"
             value={mcpConfig.allowed_tools}
             onChange={(e) =>
               setMcpConfig({ ...mcpConfig, allowed_tools: e.target.value })

--- a/components/mcp-tools-list.tsx
+++ b/components/mcp-tools-list.tsx
@@ -14,7 +14,7 @@ export default function McpToolsList({ item }: Props) {
       <div className="flex items-start mt-1 gap-2">
         <div
           className={
-            `text-zinc-500 text-xs whitespace-pre-wrap transition-all duration-200 ` +
+            `text-xs text-muted-foreground whitespace-pre-wrap transition-all duration-200 ` +
             (expanded ? "line-clamp-none" : "line-clamp-1 overflow-hidden")
           }
           style={{ maxWidth: 400 }}
@@ -22,7 +22,7 @@ export default function McpToolsList({ item }: Props) {
           {description}
         </div>
         <div
-          className="flex items-center text-xs text-gray-500 focus:outline-none select-none cursor-pointer"
+          className="flex items-center text-xs text-muted-foreground focus:outline-none select-none cursor-pointer"
           onClick={() => setExpanded((prev) => !prev)}
         >
           <ChevronRight
@@ -39,7 +39,7 @@ export default function McpToolsList({ item }: Props) {
   return (
     <div className="flex flex-col">
       <div className="flex">
-        <div className="mr-4 rounded-[16px] px-4 py-2 md:mr-24 text-black bg-white font-light">
+        <div className="mr-4 rounded-[16px] px-4 py-2 md:mr-24 bg-card text-foreground font-light">
           <div className="text-sm mb-2 text-blue-500">
             Server <span className="font-semibold">{item.server_label}</span>{" "}
             tools list

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -12,7 +12,7 @@ const Message: React.FC<MessageProps> = ({ message }) => {
       {message.role === "user" ? (
         <div className="flex justify-end">
           <div>
-            <div className="ml-4 rounded-[16px] px-4 py-2 md:ml-24 bg-[#ededed] text-stone-900  font-light">
+            <div className="ml-4 rounded-[16px] px-4 py-2 md:ml-24 bg-muted text-foreground font-light">
               <div>
                 <div>
                   <ReactMarkdown>
@@ -26,7 +26,7 @@ const Message: React.FC<MessageProps> = ({ message }) => {
       ) : (
         <div className="flex flex-col">
           <div className="flex">
-            <div className="mr-4 rounded-[16px] px-4 py-2 md:mr-24 text-black bg-white font-light">
+            <div className="mr-4 rounded-[16px] px-4 py-2 md:mr-24 bg-card text-foreground font-light">
               <div>
                 <ReactMarkdown>
                   {message.content[0].text as string}

--- a/components/panel-config.tsx
+++ b/components/panel-config.tsx
@@ -30,7 +30,7 @@ export default function PanelConfig({
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger asChild>
-              <h1 className="text-black font-medium">{title}</h1>
+              <h1 className="font-medium text-foreground">{title}</h1>
             </TooltipTrigger>
             <TooltipContent>
               <p>{tooltip}</p>

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,0 +1,49 @@
+"use client";
+import { createContext, useContext, useEffect, useState } from "react";
+
+export type Theme = "light" | "dark";
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>("light");
+
+  useEffect(() => {
+    const stored = (typeof window !== "undefined" && localStorage.getItem("theme")) as Theme | null;
+    const preferred = window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? "dark"
+      : "light";
+    const initial = stored ?? preferred;
+    setTheme(initial);
+    document.documentElement.classList.toggle("dark", initial === "dark");
+  }, []);
+
+  const toggleTheme = () => {
+    const next = theme === "dark" ? "light" : "dark";
+    setTheme(next);
+    document.documentElement.classList.toggle("dark", next === "dark");
+    if (typeof window !== "undefined") {
+      localStorage.setItem("theme", next);
+    }
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useTheme must be used within ThemeProvider");
+  }
+  return context;
+}
+

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,0 +1,16 @@
+"use client";
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "./theme-provider";
+
+export default function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+  return (
+    <button
+      onClick={toggleTheme}
+      className="inline-flex items-center justify-center rounded-md border p-2 hover:bg-accent hover:text-accent-foreground"
+      aria-label="Toggle theme"
+    >
+      {theme === "dark" ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+    </button>
+  );
+}

--- a/components/tool-call.tsx
+++ b/components/tool-call.tsx
@@ -14,7 +14,7 @@ function ApiCallCell({ toolCall }: ToolCallProps) {
     <div className="flex flex-col w-[70%] relative mb-[-8px]">
       <div>
         <div className="flex flex-col text-sm rounded-[16px]">
-          <div className="font-semibold p-3 pl-0 text-gray-700 rounded-b-none flex gap-2">
+          <div className="font-semibold p-3 pl-0 text-foreground rounded-b-none flex gap-2">
             <div className="flex gap-2 items-center text-blue-500 ml-[-8px]">
               <Zap size={16} />
               <div className="text-sm font-medium">
@@ -25,11 +25,11 @@ function ApiCallCell({ toolCall }: ToolCallProps) {
             </div>
           </div>
 
-          <div className="bg-[#fafafa] rounded-xl py-2 ml-4 mt-2">
+          <div className="rounded-xl py-2 ml-4 mt-2 bg-muted">
             <div className="max-h-96 overflow-y-scroll text-xs border-b mx-6 p-2">
               <SyntaxHighlighter
                 customStyle={{
-                  backgroundColor: "#fafafa",
+                  backgroundColor: "transparent",
                   padding: "8px",
                   paddingLeft: "0px",
                   marginTop: 0,
@@ -44,8 +44,8 @@ function ApiCallCell({ toolCall }: ToolCallProps) {
             <div className="max-h-96 overflow-y-scroll mx-6 p-2 text-xs">
               {toolCall.output ? (
                 <SyntaxHighlighter
-                  customStyle={{
-                    backgroundColor: "#fafafa",
+                customStyle={{
+                    backgroundColor: "transparent",
                     padding: "8px",
                     paddingLeft: "0px",
                     marginTop: 0,
@@ -56,7 +56,7 @@ function ApiCallCell({ toolCall }: ToolCallProps) {
                   {JSON.stringify(JSON.parse(toolCall.output), null, 2)}
                 </SyntaxHighlighter>
               ) : (
-                <div className="text-zinc-500 flex items-center gap-2 py-2">
+                <div className="flex items-center gap-2 py-2 text-muted-foreground">
                   <Clock size={16} /> Waiting for result...
                 </div>
               )}
@@ -99,7 +99,7 @@ function McpCallCell({ toolCall }: ToolCallProps) {
     <div className="flex flex-col w-[70%] relative mb-[-8px]">
       <div>
         <div className="flex flex-col text-sm rounded-[16px]">
-          <div className="font-semibold p-3 pl-0 text-gray-700 rounded-b-none flex gap-2">
+          <div className="font-semibold p-3 pl-0 text-foreground rounded-b-none flex gap-2">
             <div className="flex gap-2 items-center text-blue-500 ml-[-8px]">
               <Zap size={16} />
               <div className="text-sm font-medium">
@@ -110,11 +110,11 @@ function McpCallCell({ toolCall }: ToolCallProps) {
             </div>
           </div>
 
-          <div className="bg-[#fafafa] rounded-xl py-2 ml-4 mt-2">
+          <div className="rounded-xl py-2 ml-4 mt-2 bg-muted">
             <div className="max-h-96 overflow-y-scroll text-xs border-b mx-6 p-2">
               <SyntaxHighlighter
                 customStyle={{
-                  backgroundColor: "#fafafa",
+                  backgroundColor: "transparent",
                   padding: "8px",
                   paddingLeft: "0px",
                   marginTop: 0,
@@ -129,8 +129,8 @@ function McpCallCell({ toolCall }: ToolCallProps) {
             <div className="max-h-96 overflow-y-scroll mx-6 p-2 text-xs">
               {toolCall.output ? (
                 <SyntaxHighlighter
-                  customStyle={{
-                    backgroundColor: "#fafafa",
+                customStyle={{
+                    backgroundColor: "transparent",
                     padding: "8px",
                     paddingLeft: "0px",
                     marginTop: 0,
@@ -148,7 +148,7 @@ function McpCallCell({ toolCall }: ToolCallProps) {
                   })()}
                 </SyntaxHighlighter>
               ) : (
-                <div className="text-zinc-500 flex items-center gap-2 py-2">
+                <div className="flex items-center gap-2 py-2 text-muted-foreground">
                   <Clock size={16} /> Waiting for result...
                 </div>
               )}
@@ -164,7 +164,7 @@ function CodeInterpreterCell({ toolCall }: ToolCallProps) {
   return (
     <div className="flex flex-col w-[70%] relative mb-[-8px]">
       <div className="flex flex-col text-sm rounded-[16px]">
-        <div className="font-semibold p-3 pl-0 text-gray-700 rounded-b-none flex gap-2">
+        <div className="font-semibold p-3 pl-0 text-foreground rounded-b-none flex gap-2">
           <div className="flex gap-2 items-center text-blue-500 ml-[-8px]">
             <Code2 size={16} />
             <div className="text-sm font-medium">
@@ -174,11 +174,11 @@ function CodeInterpreterCell({ toolCall }: ToolCallProps) {
             </div>
           </div>
         </div>
-        <div className="bg-[#fafafa] rounded-xl py-2 ml-4 mt-2">
+        <div className="rounded-xl py-2 ml-4 mt-2 bg-muted">
           <div className="mx-6 p-2 text-xs">
             <SyntaxHighlighter
               customStyle={{
-                backgroundColor: "#fafafa",
+                backgroundColor: "transparent",
                 padding: "8px",
                 paddingLeft: "0px",
                 marginTop: 0,
@@ -203,7 +203,7 @@ function CodeInterpreterCell({ toolCall }: ToolCallProps) {
                     : ""
                 }`}
                 download
-                className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-[#ededed] text-xs text-zinc-500"
+                className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-muted text-xs text-muted-foreground"
               >
                 {f.filename || f.file_id}
                 <Download size={12} />

--- a/components/websearch-config.tsx
+++ b/components/websearch-config.tsx
@@ -36,15 +36,15 @@ export default function WebSearchSettings() {
   return (
     <div>
       <div className="flex items-center justify-between">
-        <div className="text-zinc-600 text-sm">User&apos;s location</div>
+        <div className="text-sm text-muted-foreground">User&apos;s location</div>
         <div
-          className="text-zinc-400 text-sm px-1 transition-colors hover:text-zinc-600 cursor-pointer"
+          className="px-1 text-sm text-muted-foreground transition-colors hover:text-foreground cursor-pointer"
           onClick={handleClear}
         >
           Clear
         </div>
       </div>
-      <div className="mt-3 space-y-3 text-zinc-400">
+      <div className="mt-3 space-y-3 text-muted-foreground">
         <div className="flex items-center gap-2">
           <label htmlFor="country" className="text-sm w-20">
             Country
@@ -63,7 +63,7 @@ export default function WebSearchSettings() {
             id="region"
             type="text"
             placeholder="Region"
-            className="bg-white border text-sm flex-1 text-zinc-900 placeholder:text-zinc-400"
+            className="bg-background border text-sm flex-1 text-foreground placeholder:text-muted-foreground"
             value={webSearchConfig.user_location?.region ?? ""}
             onChange={(e) => handleLocationChange("region", e.target.value)}
           />
@@ -77,7 +77,7 @@ export default function WebSearchSettings() {
             id="city"
             type="text"
             placeholder="City"
-            className="bg-white border text-sm flex-1 text-zinc-900 placeholder:text-zinc-400"
+            className="bg-background border text-sm flex-1 text-foreground placeholder:text-muted-foreground"
             value={webSearchConfig.user_location?.city ?? ""}
             onChange={(e) => handleLocationChange("city", e.target.value)}
           />


### PR DESCRIPTION
## Summary
- add custom theme provider and toggle button for light and dark modes
- refactor components to use semantic color tokens for dark mode compatibility
- integrate theme provider in layout and replace hardcoded colors across UI

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b85db379a883268f19ba842b7dbc6c