### PR TITLE
feat: add domain filtering for web search

### DIFF
--- a/components/websearch-config.tsx
+++ b/components/websearch-config.tsx
@@ -16,6 +16,8 @@ export default function WebSearchSettings() {
         region: "",
         city: "",
       },
+      include_domains: [],
+      exclude_domains: [],
     });
   };
 
@@ -30,6 +32,19 @@ export default function WebSearchSettings() {
         ...webSearchConfig.user_location,
         [field]: value,
       },
+    });
+  };
+
+  const handleDomainsChange = (
+    field: "include_domains" | "exclude_domains",
+    value: string
+  ) => {
+    setWebSearchConfig({
+      ...webSearchConfig,
+      [field]: value
+        .split(",")
+        .map((d) => d.trim())
+        .filter((d) => d),
     });
   };
 
@@ -80,6 +95,38 @@ export default function WebSearchSettings() {
             className="bg-white border text-sm flex-1 text-zinc-900 placeholder:text-zinc-400"
             value={webSearchConfig.user_location?.city ?? ""}
             onChange={(e) => handleLocationChange("city", e.target.value)}
+          />
+        </div>
+
+        <div className="flex items-center gap-2">
+          <label htmlFor="include_domains" className="text-sm w-20">
+            Include
+          </label>
+          <Input
+            id="include_domains"
+            type="text"
+            placeholder="example.com, example.org"
+            className="bg-white border text-sm flex-1 text-zinc-900 placeholder:text-zinc-400"
+            value={webSearchConfig.include_domains?.join(", ") ?? ""}
+            onChange={(e) =>
+              handleDomainsChange("include_domains", e.target.value)
+            }
+          />
+        </div>
+
+        <div className="flex items-center gap-2">
+          <label htmlFor="exclude_domains" className="text-sm w-20">
+            Exclude
+          </label>
+          <Input
+            id="exclude_domains"
+            type="text"
+            placeholder="example.com, example.org"
+            className="bg-white border text-sm flex-1 text-zinc-900 placeholder:text-zinc-400"
+            value={webSearchConfig.exclude_domains?.join(", ") ?? ""}
+            onChange={(e) =>
+              handleDomainsChange("exclude_domains", e.target.value)
+            }
           />
         </div>
       </div>

--- a/lib/tools/tools.ts
+++ b/lib/tools/tools.ts
@@ -34,6 +34,12 @@ export const getTools = async (toolsState: ToolsState) => {
     ) {
       webSearchTool.user_location = webSearchConfig.user_location;
     }
+    if (webSearchConfig.include_domains?.length) {
+      webSearchTool.include_domains = webSearchConfig.include_domains;
+    }
+    if (webSearchConfig.exclude_domains?.length) {
+      webSearchTool.exclude_domains = webSearchConfig.exclude_domains;
+    }
 
     tools.push(webSearchTool);
   }

--- a/stores/useToolsStore.ts
+++ b/stores/useToolsStore.ts
@@ -21,6 +21,8 @@ export type WebSearchConfig = {
     city?: string;
     region?: string;
   };
+  include_domains?: string[];
+  exclude_domains?: string[];
 };
 
 export type McpConfig = {
@@ -76,6 +78,8 @@ const useToolsStore = create<StoreState>()(
           city: "",
           region: "",
         },
+        include_domains: [],
+        exclude_domains: [],
       },
       mcpConfig: {
         server_label: "",


### PR DESCRIPTION
## Summary
- allow users to specify domains to include or exclude in web searches
- add UI controls for configuring allowed or blocked domains
- send domain filters in web search tool configuration

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b921d70d5c8326949cccb1066794b4