### PR TITLE
feat: add web search domain filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Features:
 - Streaming responses & tool calls
 - Function calling
 - Display annotations
-- Web search tool configuration
+ - Web search tool configuration, including domain filtering
 - Vector store creation & file upload for use with the file search tool
 - MCP server configuration
 - Google Calendar & Gmail integration via first-party connector

--- a/components/websearch-config.tsx
+++ b/components/websearch-config.tsx
@@ -8,8 +8,9 @@ import CountrySelector from "./country-selector";
 export default function WebSearchSettings() {
   const { webSearchConfig, setWebSearchConfig } = useToolsStore();
 
-  const handleClear = () => {
+  const handleLocationClear = () => {
     setWebSearchConfig({
+      ...webSearchConfig,
       user_location: {
         type: "approximate",
         country: "",
@@ -33,13 +34,34 @@ export default function WebSearchSettings() {
     });
   };
 
+  const handleDomainChange = (
+    field: "include_domains" | "exclude_domains",
+    value: string
+  ) => {
+    setWebSearchConfig({
+      ...webSearchConfig,
+      [field]: value
+        .split(",")
+        .map((d) => d.trim())
+        .filter((d) => d),
+    });
+  };
+
+  const handleDomainClear = () => {
+    setWebSearchConfig({
+      ...webSearchConfig,
+      include_domains: [],
+      exclude_domains: [],
+    });
+  };
+
   return (
     <div>
       <div className="flex items-center justify-between">
         <div className="text-zinc-600 text-sm">User&apos;s location</div>
         <div
           className="text-zinc-400 text-sm px-1 transition-colors hover:text-zinc-600 cursor-pointer"
-          onClick={handleClear}
+          onClick={handleLocationClear}
         >
           Clear
         </div>
@@ -80,6 +102,47 @@ export default function WebSearchSettings() {
             className="bg-white border text-sm flex-1 text-zinc-900 placeholder:text-zinc-400"
             value={webSearchConfig.user_location?.city ?? ""}
             onChange={(e) => handleLocationChange("city", e.target.value)}
+          />
+        </div>
+      </div>
+      <div className="flex items-center justify-between mt-6">
+        <div className="text-zinc-600 text-sm">Domain filtering</div>
+        <div
+          className="text-zinc-400 text-sm px-1 transition-colors hover:text-zinc-600 cursor-pointer"
+          onClick={handleDomainClear}
+        >
+          Clear
+        </div>
+      </div>
+      <div className="mt-3 space-y-3 text-zinc-400">
+        <div className="flex items-center gap-2">
+          <label htmlFor="include_domains" className="text-sm w-20">
+            Include
+          </label>
+          <Input
+            id="include_domains"
+            type="text"
+            placeholder="example.com, example.org"
+            className="bg-white border text-sm flex-1 text-zinc-900 placeholder:text-zinc-400"
+            value={(webSearchConfig.include_domains ?? []).join(", ")}
+            onChange={(e) =>
+              handleDomainChange("include_domains", e.target.value)
+            }
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <label htmlFor="exclude_domains" className="text-sm w-20">
+            Exclude
+          </label>
+          <Input
+            id="exclude_domains"
+            type="text"
+            placeholder="example.com, example.org"
+            className="bg-white border text-sm flex-1 text-zinc-900 placeholder:text-zinc-400"
+            value={(webSearchConfig.exclude_domains ?? []).join(", ")}
+            onChange={(e) =>
+              handleDomainChange("exclude_domains", e.target.value)
+            }
           />
         </div>
       </div>

--- a/lib/tools/tools.ts
+++ b/lib/tools/tools.ts
@@ -34,6 +34,12 @@ export const getTools = async (toolsState: ToolsState) => {
     ) {
       webSearchTool.user_location = webSearchConfig.user_location;
     }
+    if (webSearchConfig.include_domains && webSearchConfig.include_domains.length > 0) {
+      webSearchTool.include_domains = webSearchConfig.include_domains;
+    }
+    if (webSearchConfig.exclude_domains && webSearchConfig.exclude_domains.length > 0) {
+      webSearchTool.exclude_domains = webSearchConfig.exclude_domains;
+    }
 
     tools.push(webSearchTool);
   }

--- a/stores/useToolsStore.ts
+++ b/stores/useToolsStore.ts
@@ -21,6 +21,8 @@ export type WebSearchConfig = {
     city?: string;
     region?: string;
   };
+  include_domains?: string[];
+  exclude_domains?: string[];
 };
 
 export type McpConfig = {
@@ -76,6 +78,8 @@ const useToolsStore = create<StoreState>()(
           city: "",
           region: "",
         },
+        include_domains: [],
+        exclude_domains: [],
       },
       mcpConfig: {
         server_label: "",


### PR DESCRIPTION
## Summary
- allow filtering web search results by domain
- store include/exclude domain configuration
- document web search domain filtering feature

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b921d70d5c8326949cccb1066794b4