### PR TITLE
feat: add dark mode support

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
+import { ThemeProvider } from "@/components/theme-provider";
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -27,13 +28,15 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <div className="flex h-screen bg-gray-200 w-full flex-col  text-stone-900">
-          <main>{children}</main>
-        </div>
+        <ThemeProvider>
+          <div className="flex h-screen w-full flex-col bg-background text-foreground transition-colors">
+            <main className="flex-1">{children}</main>
+          </div>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import Assistant from "@/components/assistant";
 import ToolsPanel from "@/components/tools-panel";
+import ThemeToggle from "@/components/theme-toggle";
 import { Menu, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
@@ -23,26 +24,39 @@ export default function Main() {
   }, [router, resetConversation]);
 
   return (
-    <div className="flex justify-center h-screen">
+    <div className="relative flex h-screen w-full justify-center">
+      <div className="absolute left-4 top-4 z-30 flex items-center gap-2">
+        <ThemeToggle />
+      </div>
       <div className="w-full md:w-[70%]">
         <Assistant />
       </div>
-      <div className=" hidden md:block w-[30%]">
+      <div className="hidden w-[30%] md:block">
         <ToolsPanel />
       </div>
       {/* Hamburger menu for small screens */}
       <div className="absolute top-4 right-4 md:hidden">
-        <button onClick={() => setIsToolsPanelOpen(true)}>
-          <Menu size={24} />
+        <button
+          onClick={() => setIsToolsPanelOpen(true)}
+          className="flex h-10 w-10 items-center justify-center rounded-full border border-border bg-card text-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label="Open tools panel"
+        >
+          <Menu size={20} />
         </button>
       </div>
       {/* Overlay panel for ToolsPanel on small screens */}
       {isToolsPanelOpen && (
-        <div className="fixed inset-0 z-50 flex justify-end bg-black bg-opacity-30">
-          <div className="w-full bg-white h-full p-4">
-            <button className="mb-4" onClick={() => setIsToolsPanelOpen(false)}>
-              <X size={24} />
-            </button>
+        <div className="fixed inset-0 z-40 flex justify-end bg-black/30 backdrop-blur-sm transition-colors dark:bg-black/60">
+          <div className="flex h-full w-full max-w-sm flex-col bg-background p-4 shadow-lg">
+            <div className="mb-4 flex justify-end">
+              <button
+                className="flex h-10 w-10 items-center justify-center rounded-full border border-border bg-card text-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                onClick={() => setIsToolsPanelOpen(false)}
+                aria-label="Close tools panel"
+              >
+                <X size={20} />
+              </button>
+            </div>
             <ToolsPanel />
           </div>
         </div>

--- a/components/annotations.tsx
+++ b/components/annotations.tsx
@@ -15,7 +15,7 @@ export type Annotation = {
 
 const AnnotationPill = ({ annotation }: { annotation: Annotation }) => {
   const className =
-    "inline-block text-nowrap px-3 py-1 rounded-full text-xs max-w-48 shrink-0 text-ellipsis overflow-hidden bg-[#ededed] text-zinc-500";
+    "inline-block max-w-48 shrink-0 overflow-hidden text-ellipsis text-nowrap rounded-full bg-muted px-3 py-1 text-xs text-muted-foreground transition-colors";
 
   switch (annotation.type) {
     case "file_citation":

--- a/components/assistant.tsx
+++ b/components/assistant.tsx
@@ -49,7 +49,7 @@ export default function Assistant() {
   };
 
   return (
-    <div className="h-full p-4 w-full bg-white">
+    <div className="h-full w-full bg-card p-4 transition-colors">
       <Chat
         items={chatMessages}
         onSendMessage={handleSendMessage}

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -47,7 +47,7 @@ const Chat: React.FC<ChatProps> = ({
   }, [items]);
 
   return (
-    <div className="flex justify-center items-center size-full">
+    <div className="flex size-full items-center justify-center transition-colors">
       <div className="flex grow flex-col h-full max-w-[750px] gap-2">
         <div className="h-[90vh] overflow-y-scroll px-10 flex flex-col">
           <div className="mt-auto space-y-5 pt-4">
@@ -83,8 +83,8 @@ const Chat: React.FC<ChatProps> = ({
         <div className="flex-1 p-4 px-10">
           <div className="flex items-center">
             <div className="flex w-full items-center pb-4 md:pb-1">
-              <div className="flex w-full flex-col gap-1.5 rounded-[20px] p-2.5 pl-1.5 transition-colors bg-white border border-stone-200 shadow-sm">
-                <div className="flex items-end gap-1.5 md:gap-2 pl-4">
+              <div className="flex w-full flex-col gap-1.5 rounded-[20px] border border-border bg-card p-2.5 pl-1.5 shadow-sm transition-colors">
+                <div className="flex items-end gap-1.5 pl-4 md:gap-2">
                   <div className="flex min-w-0 flex-1 flex-col">
                     <textarea
                       id="prompt-textarea"
@@ -92,7 +92,7 @@ const Chat: React.FC<ChatProps> = ({
                       dir="auto"
                       rows={2}
                       placeholder="Message..."
-                      className="mb-2 resize-none border-0 focus:outline-none text-sm bg-transparent px-0 pb-6 pt-2"
+                      className="mb-2 resize-none border-0 bg-transparent px-0 pb-6 pt-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none"
                       value={inputMessageText}
                       onChange={(e) => setinputMessageText(e.target.value)}
                       onKeyDown={handleKeyDown}
@@ -103,8 +103,8 @@ const Chat: React.FC<ChatProps> = ({
                   <button
                     disabled={!inputMessageText}
                     data-testid="send-button"
-                    className="flex size-8 items-end justify-center rounded-full bg-black text-white transition-colors hover:opacity-70 focus-visible:outline-none focus-visible:outline-black disabled:bg-[#D7D7D7] disabled:text-[#f4f4f4] disabled:hover:opacity-100"
-                  onClick={() => {
+                    className="flex size-9 items-center justify-center rounded-full bg-primary text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:bg-muted disabled:text-muted-foreground disabled:hover:bg-muted"
+                    onClick={() => {
                       onSendMessage(inputMessageText);
                       setinputMessageText("");
                     }}

--- a/components/file-search-setup.tsx
+++ b/components/file-search-setup.tsx
@@ -35,7 +35,7 @@ export default function FileSearchSetup() {
 
   return (
     <div>
-      <div className="text-sm text-zinc-500">
+      <div className="text-sm text-muted-foreground">
         Upload a file to create a new vector store, or use an existing one.
       </div>
       <div className="flex items-center gap-2 mt-2 h-10">
@@ -46,7 +46,7 @@ export default function FileSearchSetup() {
           {vectorStore?.id ? (
             <div className="flex items-center justify-between flex-1 min-w-0">
               <div className="flex items-center gap-2 min-w-0">
-                <div className="text-zinc-400  text-xs font-mono flex-1 text-ellipsis truncate">
+                <div className="text-xs font-mono text-muted-foreground flex-1 text-ellipsis truncate">
                   {vectorStore.id}
                 </div>
                 <TooltipProvider>
@@ -55,7 +55,7 @@ export default function FileSearchSetup() {
                       <CircleX
                         onClick={() => unlinkStore()}
                         size={16}
-                        className="cursor-pointer text-zinc-400 mb-0.5 shrink-0 mt-0.5 hover:text-zinc-700 transition-all"
+                        className="mb-0.5 mt-0.5 shrink-0 cursor-pointer text-muted-foreground transition-all hover:text-foreground"
                       />
                     </TooltipTrigger>
                     <TooltipContent className="mr-2">
@@ -72,7 +72,7 @@ export default function FileSearchSetup() {
                 placeholder="ID (vs_XXXX...)"
                 value={newStoreId}
                 onChange={(e) => setNewStoreId(e.target.value)}
-                className="border border-zinc-300 rounded text-sm bg-white"
+                className="rounded text-sm"
                 onKeyDown={(e) => {
                   if (e.key === "Enter") {
                     handleAddStore(newStoreId);
@@ -80,7 +80,7 @@ export default function FileSearchSetup() {
                 }}
               />
               <div
-                className="text-zinc-400 text-sm px-1 transition-colors hover:text-zinc-600 cursor-pointer"
+                className="cursor-pointer px-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
                 onClick={() => handleAddStore(newStoreId)}
               >
                 Add

--- a/components/file-upload.tsx
+++ b/components/file-upload.tsx
@@ -174,7 +174,7 @@ export default function FileUpload({
   return (
     <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
       <DialogTrigger asChild>
-        <div className="bg-white rounded-full flex items-center justify-center py-1 px-3 border border-zinc-200 gap-1 font-medium text-sm cursor-pointer hover:bg-zinc-50 transition-all">
+        <div className="flex cursor-pointer items-center justify-center gap-1 rounded-full border border-border bg-card py-1 px-3 text-sm font-medium text-foreground transition-colors hover:bg-accent hover:text-accent-foreground">
           <Plus size={16} />
           Upload
         </div>
@@ -186,10 +186,10 @@ export default function FileUpload({
           </DialogHeader>
           <div className="my-6">
             {!vectorStoreId || vectorStoreId === "" ? (
-              <div className="flex items-start gap-2 text-sm">
+              <div className="flex items-start gap-2 text-sm text-foreground">
                 <label className="font-medium w-72" htmlFor="storeName">
                   New vector store name
-                  <div className="text-xs text-zinc-400">
+                  <div className="text-xs text-muted-foreground">
                     A new store will be created when you upload a file.
                   </div>
                 </label>
@@ -198,7 +198,7 @@ export default function FileUpload({
                   type="text"
                   value={newStoreName}
                   onChange={(e) => setNewStoreName(e.target.value)}
-                  className="border rounded p-2"
+                  className="rounded p-2"
                 />
               </div>
             ) : (
@@ -207,7 +207,7 @@ export default function FileUpload({
                   <div className="text-sm font-medium w-24 text-nowrap">
                     Vector store
                   </div>
-                  <div className="text-zinc-400  text-xs font-mono flex-1 text-ellipsis truncate">
+                  <div className="text-xs font-mono text-muted-foreground flex-1 text-ellipsis truncate">
                     {vectorStoreId}
                   </div>
                   <TooltipProvider>
@@ -216,7 +216,7 @@ export default function FileUpload({
                         <CircleX
                           onClick={() => onUnlinkStore()}
                           size={16}
-                          className="cursor-pointer text-zinc-400 mb-0.5 shrink-0 mt-0.5 hover:text-zinc-700 transition-all"
+                          className="mb-0.5 mt-0.5 shrink-0 cursor-pointer text-muted-foreground transition-all hover:text-foreground"
                         />
                       </TooltipTrigger>
                       <TooltipContent>
@@ -228,17 +228,17 @@ export default function FileUpload({
               </div>
             )}
           </div>
-          <div className="flex justify-center items-center mb-4 h-[200px]">
+          <div className="mb-4 flex h-[200px] items-center justify-center">
             {file ? (
-              <div className="flex flex-col items-start">
-                <div className="text-zinc-400">Loaded file</div>
-                <div className="flex items-center mt-2">
-                  <div className="text-zinc-900 mr-2">{file.name}</div>
+              <div className="flex flex-col items-start text-foreground">
+                <div className="text-muted-foreground">Loaded file</div>
+                <div className="mt-2 flex items-center">
+                  <div className="mr-2">{file.name}</div>
 
                   <Trash2
                     onClick={removeFile}
                     size={16}
-                    className="cursor-pointer text-zinc-900"
+                    className="cursor-pointer text-muted-foreground transition-colors hover:text-foreground"
                   />
                 </div>
               </div>
@@ -246,19 +246,19 @@ export default function FileUpload({
               <div className="flex flex-col items-center">
                 <div
                   {...getRootProps()}
-                  className="p-6 flex items-center justify-center relative focus-visible:outline-0"
+                  className="relative flex items-center justify-center p-6 focus-visible:outline-0"
                 >
                   <input {...getInputProps()} />
                   <div
                     className={`absolute rounded-full transition-all duration-300 ${
                       isDragActive
-                        ? "h-56 w-56 bg-zinc-100"
+                        ? "h-56 w-56 bg-accent"
                         : "h-0 w-0 bg-transparent"
                     }`}
                   ></div>
-                  <div className="flex flex-col items-center text-center z-10 cursor-pointer">
-                    <FilePlus2 className="mb-4 size-8 text-zinc-700" />
-                    <div className="text-zinc-700">Upload a file</div>
+                  <div className="z-10 flex cursor-pointer flex-col items-center text-center text-muted-foreground">
+                    <FilePlus2 className="mb-4 size-8" />
+                    <div>Upload a file</div>
                   </div>
                 </div>
               </div>

--- a/components/functions-view.tsx
+++ b/components/functions-view.tsx
@@ -17,9 +17,9 @@ const getToolArgs = (parameters: {
   return (
     <div className="ml-4">
       {Object.entries(parameters).map(([key, value]) => (
-        <div key={key} className="flex items-center text-xs space-x-2 my-1">
-          <span className="text-blue-500">{key}:</span>
-          <span className="text-zinc-400">{value?.type}</span>
+        <div key={key} className="my-1 flex items-center space-x-2 text-xs">
+          <span className="text-primary">{key}:</span>
+          <span className="text-muted-foreground">{value?.type}</span>
         </div>
       ))}
     </div>
@@ -31,10 +31,10 @@ export default function FunctionsView() {
     <div className="flex flex-col space-y-4">
       {toolsList.map((tool) => (
         <div key={tool.name} className="flex items-start gap-2">
-          <div className="bg-blue-100 text-blue-500 rounded-md p-1">
+          <div className="rounded-md bg-primary/10 p-1 text-primary">
             <Code size={16} />
           </div>
-          <div className="text-zinc-800 font-mono text-sm mt-0.5">
+          <div className="mt-0.5 font-mono text-sm text-foreground">
             {tool.name}(
             {tool.parameters && Object.keys(tool.parameters).length > 0
               ? getToolArgs(tool.parameters)

--- a/components/google-integration.tsx
+++ b/components/google-integration.tsx
@@ -65,11 +65,11 @@ export default function GoogleIntegrationPanel() {
         </div>
       ) : (
         <div className="space-y-2">
-          <div className="flex items-center gap-2 rounded-lg shadow-sm border p-3 bg-white">
-            <div className="bg-blue-100 text-blue-500 rounded-md p-1">
+          <div className="flex items-center gap-2 rounded-lg border border-border bg-card p-3 shadow-sm transition-colors">
+            <div className="rounded-md bg-primary/10 p-1 text-primary">
               <Check size={16} />
             </div>
-            <p className="text-sm text-zinc-800">Google OAuth set up</p>
+            <p className="text-sm text-card-foreground">Google OAuth set up</p>
           </div>
         </div>
       )}

--- a/components/loading-message.tsx
+++ b/components/loading-message.tsx
@@ -2,11 +2,11 @@ import React from "react";
 
 const LoadingMessage: React.FC = () => {
   return (
-    <div className="text-sm">
+    <div className="text-sm text-foreground transition-colors">
       <div className="flex flex-col">
         <div className="flex">
-          <div className="mr-4 rounded-[16px] px-4 py-2 md:mr-24 text-black bg-white font-light">
-            <div className="w-3 h-3 animate-pulse bg-black rounded-full" />
+          <div className="mr-4 rounded-[16px] bg-card px-4 py-2 font-light text-card-foreground transition-colors md:mr-24">
+            <div className="h-3 w-3 animate-pulse rounded-full bg-primary" />
           </div>
         </div>
       </div>

--- a/components/mcp-approval.tsx
+++ b/components/mcp-approval.tsx
@@ -19,8 +19,8 @@ export default function McpApproval({ item, onRespond }: Props) {
   return (
     <div className="flex flex-col">
       <div className="flex">
-        <div className="mr-4 rounded-[16px] p-4 md:mr-24 text-black bg-gray-100 font-light">
-          <div className="mb-2 text-sm">
+        <div className="mr-4 rounded-[16px] bg-card p-4 font-light text-card-foreground transition-colors md:mr-24">
+          <div className="mb-2 text-sm text-foreground">
             Request to execute tool{" "}
             <span className="font-medium">{item.name}</span> on server{" "}
             <span className="font-medium">{item.server_label}</span>.
@@ -33,7 +33,7 @@ export default function McpApproval({ item, onRespond }: Props) {
               size="sm"
               disabled={disabled}
               onClick={() => handle(false)}
-              className="bg-gray-200 text-gray-700 hover:bg-gray-300 hover:text-gray-800"
+              variant="outline"
             >
               Decline
             </Button>

--- a/components/mcp-config.tsx
+++ b/components/mcp-config.tsx
@@ -19,15 +19,15 @@ export default function McpConfig() {
   return (
     <div>
       <div className="flex items-center justify-between">
-        <div className="text-zinc-600 text-sm">Server details</div>
+        <div className="text-sm text-muted-foreground">Server details</div>
         <div
-          className="text-zinc-400 text-sm px-1 transition-colors hover:text-zinc-600 cursor-pointer"
+          className="cursor-pointer px-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
           onClick={handleClear}
         >
           Clear
         </div>
       </div>
-      <div className="mt-3 space-y-3 text-zinc-400">
+      <div className="mt-3 space-y-3 text-muted-foreground">
         <div className="flex items-center gap-2">
           <label htmlFor="server_label" className="text-sm w-24">
             Label
@@ -36,7 +36,7 @@ export default function McpConfig() {
             id="server_label"
             type="text"
             placeholder="deepwiki"
-            className="bg-white border text-sm flex-1 text-zinc-900 placeholder:text-zinc-400"
+            className="flex-1 text-sm"
             value={mcpConfig.server_label}
             onChange={(e) =>
               setMcpConfig({ ...mcpConfig, server_label: e.target.value })
@@ -51,7 +51,7 @@ export default function McpConfig() {
             id="server_url"
             type="text"
             placeholder="https://example.com/mcp"
-            className="bg-white border text-sm flex-1 text-zinc-900 placeholder:text-zinc-400"
+            className="flex-1 text-sm"
             value={mcpConfig.server_url}
             onChange={(e) =>
               setMcpConfig({ ...mcpConfig, server_url: e.target.value })
@@ -66,7 +66,7 @@ export default function McpConfig() {
             id="allowed_tools"
             type="text"
             placeholder="tool1,tool2"
-            className="bg-white border text-sm flex-1 text-zinc-900 placeholder:text-zinc-400"
+            className="flex-1 text-sm"
             value={mcpConfig.allowed_tools}
             onChange={(e) =>
               setMcpConfig({ ...mcpConfig, allowed_tools: e.target.value })

--- a/components/mcp-tools-list.tsx
+++ b/components/mcp-tools-list.tsx
@@ -14,7 +14,7 @@ export default function McpToolsList({ item }: Props) {
       <div className="flex items-start mt-1 gap-2">
         <div
           className={
-            `text-zinc-500 text-xs whitespace-pre-wrap transition-all duration-200 ` +
+            `text-muted-foreground text-xs whitespace-pre-wrap transition-all duration-200 ` +
             (expanded ? "line-clamp-none" : "line-clamp-1 overflow-hidden")
           }
           style={{ maxWidth: 400 }}
@@ -22,7 +22,7 @@ export default function McpToolsList({ item }: Props) {
           {description}
         </div>
         <div
-          className="flex items-center text-xs text-gray-500 focus:outline-none select-none cursor-pointer"
+          className="flex cursor-pointer select-none items-center text-xs text-muted-foreground focus:outline-none"
           onClick={() => setExpanded((prev) => !prev)}
         >
           <ChevronRight
@@ -39,16 +39,16 @@ export default function McpToolsList({ item }: Props) {
   return (
     <div className="flex flex-col">
       <div className="flex">
-        <div className="mr-4 rounded-[16px] px-4 py-2 md:mr-24 text-black bg-white font-light">
-          <div className="text-sm mb-2 text-blue-500">
+        <div className="mr-4 rounded-[16px] bg-card px-4 py-2 font-light text-card-foreground transition-colors md:mr-24">
+          <div className="mb-2 text-sm text-primary">
             Server <span className="font-semibold">{item.server_label}</span>{" "}
             tools list
           </div>
-          <div className="space-y-2 text-sm mt-3">
+          <div className="mt-3 space-y-2 text-sm">
             {item.tools.map((tool) => (
               <div key={tool.name}>
-                <div className="flex gap-2 items-center text-xs">
-                  <div className="bg-blue-100 text-blue-500 rounded-md p-1">
+                <div className="flex items-center gap-2 text-xs">
+                  <div className="rounded-md bg-primary/10 p-1 text-primary">
                     <Code size={12} />
                   </div>
                   <div className="font-mono">{tool.name}</div>

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @next/next/no-img-element */
 import { MessageItem } from "@/lib/assistant";
 import React from "react";
 import ReactMarkdown from "react-markdown";
@@ -8,11 +9,11 @@ interface MessageProps {
 
 const Message: React.FC<MessageProps> = ({ message }) => {
   return (
-    <div className="text-sm">
+    <div className="text-sm text-foreground transition-colors">
       {message.role === "user" ? (
         <div className="flex justify-end">
           <div>
-            <div className="ml-4 rounded-[16px] px-4 py-2 md:ml-24 bg-[#ededed] text-stone-900  font-light">
+            <div className="ml-4 rounded-[16px] bg-secondary px-4 py-2 font-light text-secondary-foreground md:ml-24">
               <div>
                 <div>
                   <ReactMarkdown>
@@ -26,7 +27,7 @@ const Message: React.FC<MessageProps> = ({ message }) => {
       ) : (
         <div className="flex flex-col">
           <div className="flex">
-            <div className="mr-4 rounded-[16px] px-4 py-2 md:mr-24 text-black bg-white font-light">
+            <div className="mr-4 rounded-[16px] bg-card px-4 py-2 font-light text-card-foreground transition-colors md:mr-24">
               <div>
                 <ReactMarkdown>
                   {message.content[0].text as string}

--- a/components/panel-config.tsx
+++ b/components/panel-config.tsx
@@ -30,7 +30,7 @@ export default function PanelConfig({
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger asChild>
-              <h1 className="text-black font-medium">{title}</h1>
+              <h1 className="font-medium text-foreground transition-colors">{title}</h1>
             </TooltipTrigger>
             <TooltipContent>
               <p>{tooltip}</p>

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+type Theme = "light" | "dark";
+
+type ThemeContextValue = {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+  isLoaded: boolean;
+};
+
+const STORAGE_KEY = "responses-theme";
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+export function ThemeProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [theme, setTheme] = useState<Theme>("light");
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const storedTheme = window.localStorage.getItem(STORAGE_KEY) as Theme | null;
+    if (storedTheme === "light" || storedTheme === "dark") {
+      setTheme(storedTheme);
+      document.documentElement.classList.toggle("dark", storedTheme === "dark");
+    } else {
+      const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+      const systemTheme: Theme = prefersDark ? "dark" : "light";
+      setTheme(systemTheme);
+      document.documentElement.classList.toggle("dark", prefersDark);
+    }
+    setIsLoaded(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isLoaded || typeof window === "undefined") return;
+
+    document.documentElement.classList.toggle("dark", theme === "dark");
+    window.localStorage.setItem(STORAGE_KEY, theme);
+  }, [isLoaded, theme]);
+
+  const value = useMemo(
+    () => ({
+      theme,
+      setTheme,
+      toggleTheme: () => setTheme((prev) => (prev === "dark" ? "light" : "dark")),
+      isLoaded,
+    }),
+    [theme, isLoaded]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return context;
+}

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "./theme-provider";
+
+export default function ThemeToggle() {
+  const { theme, toggleTheme, isLoaded } = useTheme();
+  const isDark = isLoaded ? theme === "dark" : false;
+
+  return (
+    <button
+      type="button"
+      aria-label="Toggle dark mode"
+      aria-pressed={isLoaded ? isDark : undefined}
+      onClick={toggleTheme}
+      className="relative flex h-10 w-10 items-center justify-center rounded-full border border-border bg-card text-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <Sun
+        className={`h-5 w-5 transition-all duration-300 ${
+          isDark ? "-rotate-90 scale-0" : "rotate-0 scale-100"
+        }`}
+      />
+      <Moon
+        className={`absolute h-5 w-5 transition-all duration-300 ${
+          isDark ? "rotate-0 scale-100" : "rotate-90 scale-0"
+        }`}
+      />
+    </button>
+  );
+}

--- a/components/tool-call.tsx
+++ b/components/tool-call.tsx
@@ -1,21 +1,31 @@
-import React from "react";
+"use client";
+import React, { useMemo } from "react";
 
 import { ToolCallItem } from "@/lib/assistant";
 import { BookOpenText, Clock, Globe, Zap, Code2, Download } from "lucide-react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
-import { coy } from "react-syntax-highlighter/dist/esm/styles/prism";
+import { coy, duotoneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
+import { useTheme } from "./theme-provider";
 
 interface ToolCallProps {
   toolCall: ToolCallItem;
 }
 
-function ApiCallCell({ toolCall }: ToolCallProps) {
+type SyntaxTheme = Record<string, unknown>;
+
+function ApiCallCell({
+  toolCall,
+  syntaxTheme,
+}: {
+  toolCall: ToolCallItem;
+  syntaxTheme: SyntaxTheme;
+}) {
   return (
-    <div className="flex flex-col w-[70%] relative mb-[-8px]">
+    <div className="relative mb-[-8px] flex w-[70%] flex-col">
       <div>
-        <div className="flex flex-col text-sm rounded-[16px]">
-          <div className="font-semibold p-3 pl-0 text-gray-700 rounded-b-none flex gap-2">
-            <div className="flex gap-2 items-center text-blue-500 ml-[-8px]">
+        <div className="flex flex-col rounded-[16px] text-sm">
+          <div className="flex gap-2 rounded-b-none p-3 pl-0 font-semibold text-foreground">
+            <div className="ml-[-8px] flex items-center gap-2 text-primary">
               <Zap size={16} />
               <div className="text-sm font-medium">
                 {toolCall.status === "completed"
@@ -25,38 +35,35 @@ function ApiCallCell({ toolCall }: ToolCallProps) {
             </div>
           </div>
 
-          <div className="bg-[#fafafa] rounded-xl py-2 ml-4 mt-2">
-            <div className="max-h-96 overflow-y-scroll text-xs border-b mx-6 p-2">
+          <div className="ml-4 mt-2 rounded-xl border border-border/60 bg-muted py-2">
+            <div className="mx-6 max-h-96 overflow-y-scroll border-b border-border/60 p-2 text-xs">
               <SyntaxHighlighter
                 customStyle={{
-                  backgroundColor: "#fafafa",
-                  padding: "8px",
-                  paddingLeft: "0px",
-                  marginTop: 0,
-                  marginBottom: 0,
+                  backgroundColor: "transparent",
+                  padding: "8px 0",
+                  margin: 0,
                 }}
                 language="json"
-                style={coy}
+                style={syntaxTheme}
               >
                 {JSON.stringify(toolCall.parsedArguments, null, 2)}
               </SyntaxHighlighter>
             </div>
-            <div className="max-h-96 overflow-y-scroll mx-6 p-2 text-xs">
+            <div className="mx-6 max-h-96 overflow-y-scroll p-2 text-xs">
               {toolCall.output ? (
                 <SyntaxHighlighter
                   customStyle={{
-                    backgroundColor: "#fafafa",
-                    padding: "8px",
-                    paddingLeft: "0px",
-                    marginTop: 0,
+                    backgroundColor: "transparent",
+                    padding: "8px 0",
+                    margin: 0,
                   }}
                   language="json"
-                  style={coy}
+                  style={syntaxTheme}
                 >
                   {JSON.stringify(JSON.parse(toolCall.output), null, 2)}
                 </SyntaxHighlighter>
               ) : (
-                <div className="text-zinc-500 flex items-center gap-2 py-2">
+                <div className="flex items-center gap-2 py-2 text-muted-foreground">
                   <Clock size={16} /> Waiting for result...
                 </div>
               )}
@@ -70,7 +77,7 @@ function ApiCallCell({ toolCall }: ToolCallProps) {
 
 function FileSearchCell({ toolCall }: ToolCallProps) {
   return (
-    <div className="flex gap-2 items-center text-blue-500 mb-[-16px] ml-[-8px]">
+    <div className="mb-[-16px] ml-[-8px] flex items-center gap-2 text-primary">
       <BookOpenText size={16} />
       <div className="text-sm font-medium mb-0.5">
         {toolCall.status === "completed"
@@ -83,7 +90,7 @@ function FileSearchCell({ toolCall }: ToolCallProps) {
 
 function WebSearchCell({ toolCall }: ToolCallProps) {
   return (
-    <div className="flex gap-2 items-center text-blue-500 mb-[-16px] ml-[-8px]">
+    <div className="mb-[-16px] ml-[-8px] flex items-center gap-2 text-primary">
       <Globe size={16} />
       <div className="text-sm font-medium">
         {toolCall.status === "completed"
@@ -94,13 +101,19 @@ function WebSearchCell({ toolCall }: ToolCallProps) {
   );
 }
 
-function McpCallCell({ toolCall }: ToolCallProps) {
+function McpCallCell({
+  toolCall,
+  syntaxTheme,
+}: {
+  toolCall: ToolCallItem;
+  syntaxTheme: SyntaxTheme;
+}) {
   return (
-    <div className="flex flex-col w-[70%] relative mb-[-8px]">
+    <div className="relative mb-[-8px] flex w-[70%] flex-col">
       <div>
-        <div className="flex flex-col text-sm rounded-[16px]">
-          <div className="font-semibold p-3 pl-0 text-gray-700 rounded-b-none flex gap-2">
-            <div className="flex gap-2 items-center text-blue-500 ml-[-8px]">
+        <div className="flex flex-col rounded-[16px] text-sm">
+          <div className="flex gap-2 rounded-b-none p-3 pl-0 font-semibold text-foreground">
+            <div className="ml-[-8px] flex items-center gap-2 text-primary">
               <Zap size={16} />
               <div className="text-sm font-medium">
                 {toolCall.status === "completed"
@@ -110,33 +123,30 @@ function McpCallCell({ toolCall }: ToolCallProps) {
             </div>
           </div>
 
-          <div className="bg-[#fafafa] rounded-xl py-2 ml-4 mt-2">
-            <div className="max-h-96 overflow-y-scroll text-xs border-b mx-6 p-2">
+          <div className="ml-4 mt-2 rounded-xl border border-border/60 bg-muted py-2">
+            <div className="mx-6 max-h-96 overflow-y-scroll border-b border-border/60 p-2 text-xs">
               <SyntaxHighlighter
                 customStyle={{
-                  backgroundColor: "#fafafa",
-                  padding: "8px",
-                  paddingLeft: "0px",
-                  marginTop: 0,
-                  marginBottom: 0,
+                  backgroundColor: "transparent",
+                  padding: "8px 0",
+                  margin: 0,
                 }}
                 language="json"
-                style={coy}
+                style={syntaxTheme}
               >
                 {JSON.stringify(toolCall.parsedArguments, null, 2)}
               </SyntaxHighlighter>
             </div>
-            <div className="max-h-96 overflow-y-scroll mx-6 p-2 text-xs">
+            <div className="mx-6 max-h-96 overflow-y-scroll p-2 text-xs">
               {toolCall.output ? (
                 <SyntaxHighlighter
                   customStyle={{
-                    backgroundColor: "#fafafa",
-                    padding: "8px",
-                    paddingLeft: "0px",
-                    marginTop: 0,
+                    backgroundColor: "transparent",
+                    padding: "8px 0",
+                    margin: 0,
                   }}
                   language="json"
-                  style={coy}
+                  style={syntaxTheme}
                 >
                   {(() => {
                     try {
@@ -148,7 +158,7 @@ function McpCallCell({ toolCall }: ToolCallProps) {
                   })()}
                 </SyntaxHighlighter>
               ) : (
-                <div className="text-zinc-500 flex items-center gap-2 py-2">
+                <div className="flex items-center gap-2 py-2 text-muted-foreground">
                   <Clock size={16} /> Waiting for result...
                 </div>
               )}
@@ -160,12 +170,18 @@ function McpCallCell({ toolCall }: ToolCallProps) {
   );
 }
 
-function CodeInterpreterCell({ toolCall }: ToolCallProps) {
+function CodeInterpreterCell({
+  toolCall,
+  syntaxTheme,
+}: {
+  toolCall: ToolCallItem;
+  syntaxTheme: SyntaxTheme;
+}) {
   return (
-    <div className="flex flex-col w-[70%] relative mb-[-8px]">
-      <div className="flex flex-col text-sm rounded-[16px]">
-        <div className="font-semibold p-3 pl-0 text-gray-700 rounded-b-none flex gap-2">
-          <div className="flex gap-2 items-center text-blue-500 ml-[-8px]">
+    <div className="relative mb-[-8px] flex w-[70%] flex-col">
+      <div className="flex flex-col rounded-[16px] text-sm">
+        <div className="flex gap-2 rounded-b-none p-3 pl-0 font-semibold text-foreground">
+          <div className="ml-[-8px] flex items-center gap-2 text-primary">
             <Code2 size={16} />
             <div className="text-sm font-medium">
               {toolCall.status === "completed"
@@ -174,24 +190,23 @@ function CodeInterpreterCell({ toolCall }: ToolCallProps) {
             </div>
           </div>
         </div>
-        <div className="bg-[#fafafa] rounded-xl py-2 ml-4 mt-2">
+        <div className="ml-4 mt-2 rounded-xl border border-border/60 bg-muted py-2">
           <div className="mx-6 p-2 text-xs">
             <SyntaxHighlighter
               customStyle={{
-                backgroundColor: "#fafafa",
-                padding: "8px",
-                paddingLeft: "0px",
-                marginTop: 0,
+                backgroundColor: "transparent",
+                padding: "8px 0",
+                margin: 0,
               }}
               language="python"
-              style={coy}
+              style={syntaxTheme}
             >
               {toolCall.code || ""}
             </SyntaxHighlighter>
           </div>
         </div>
         {toolCall.files && toolCall.files.length > 0 && (
-          <div className="flex gap-2 mt-2 ml-4 flex-wrap">
+          <div className="ml-4 mt-2 flex flex-wrap gap-2">
             {toolCall.files.map((f) => (
               <a
                 key={f.file_id}
@@ -203,7 +218,7 @@ function CodeInterpreterCell({ toolCall }: ToolCallProps) {
                     : ""
                 }`}
                 download
-                className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-[#ededed] text-xs text-zinc-500"
+                className="inline-flex items-center gap-1 rounded-full bg-muted px-3 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted/80"
               >
                 {f.filename || f.file_id}
                 <Download size={12} />
@@ -217,20 +232,31 @@ function CodeInterpreterCell({ toolCall }: ToolCallProps) {
 }
 
 export default function ToolCall({ toolCall }: ToolCallProps) {
+  const { theme } = useTheme();
+  const syntaxTheme = useMemo(
+    () => (theme === "dark" ? duotoneDark : coy),
+    [theme]
+  );
+
   return (
     <div className="flex justify-start pt-2">
       {(() => {
         switch (toolCall.tool_type) {
           case "function_call":
-            return <ApiCallCell toolCall={toolCall} />;
+            return <ApiCallCell toolCall={toolCall} syntaxTheme={syntaxTheme} />;
           case "file_search_call":
             return <FileSearchCell toolCall={toolCall} />;
           case "web_search_call":
             return <WebSearchCell toolCall={toolCall} />;
           case "mcp_call":
-            return <McpCallCell toolCall={toolCall} />;
+            return <McpCallCell toolCall={toolCall} syntaxTheme={syntaxTheme} />;
           case "code_interpreter_call":
-            return <CodeInterpreterCell toolCall={toolCall} />;
+            return (
+              <CodeInterpreterCell
+                toolCall={toolCall}
+                syntaxTheme={syntaxTheme}
+              />
+            );
           default:
             return null;
         }

--- a/components/tools-panel.tsx
+++ b/components/tools-panel.tsx
@@ -32,7 +32,7 @@ export default function ContextPanel() {
       .catch(() => setOauthConfigured(false));
   }, []);
   return (
-    <div className="h-full p-8 w-full bg-[#f9f9f9] rounded-t-xl md:rounded-none border-l-1 border-stone-100">
+    <div className="h-full w-full rounded-t-xl bg-muted/60 p-8 transition-colors md:rounded-none md:border-l md:border-border">
       <div className="flex flex-col overflow-y-scroll h-full">
         <PanelConfig
           title="File Search"

--- a/components/websearch-config.tsx
+++ b/components/websearch-config.tsx
@@ -36,15 +36,15 @@ export default function WebSearchSettings() {
   return (
     <div>
       <div className="flex items-center justify-between">
-        <div className="text-zinc-600 text-sm">User&apos;s location</div>
+        <div className="text-sm text-muted-foreground">User&apos;s location</div>
         <div
-          className="text-zinc-400 text-sm px-1 transition-colors hover:text-zinc-600 cursor-pointer"
+          className="cursor-pointer px-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
           onClick={handleClear}
         >
           Clear
         </div>
       </div>
-      <div className="mt-3 space-y-3 text-zinc-400">
+      <div className="mt-3 space-y-3 text-muted-foreground">
         <div className="flex items-center gap-2">
           <label htmlFor="country" className="text-sm w-20">
             Country
@@ -63,7 +63,7 @@ export default function WebSearchSettings() {
             id="region"
             type="text"
             placeholder="Region"
-            className="bg-white border text-sm flex-1 text-zinc-900 placeholder:text-zinc-400"
+            className="flex-1"
             value={webSearchConfig.user_location?.region ?? ""}
             onChange={(e) => handleLocationChange("region", e.target.value)}
           />
@@ -77,7 +77,7 @@ export default function WebSearchSettings() {
             id="city"
             type="text"
             placeholder="City"
-            className="bg-white border text-sm flex-1 text-zinc-900 placeholder:text-zinc-400"
+            className="flex-1"
             value={webSearchConfig.user_location?.city ?? ""}
             onChange={(e) => handleLocationChange("city", e.target.value)}
           />


### PR DESCRIPTION
## Summary
- add a ThemeProvider with a toggle to persist dark or light preference
- update layout and UI components to use theme tokens so the interface adapts to dark mode
- adjust syntax highlighting and styling details to remain legible in both themes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68ca0cd80a6c83268249465d44118367